### PR TITLE
implement induce

### DIFF
--- a/libintervalxt/src/intervalxt/cppyy.hpp
+++ b/libintervalxt/src/intervalxt/cppyy.hpp
@@ -28,8 +28,8 @@
 #include "intervalxt/length.hpp"
 
 namespace intervalxt {
-template <typename T, typename Q>
-std::ostream &operator<<(std::ostream &, const Length<T, Q> &);
+template <typename T>
+std::ostream &operator<<(std::ostream &, const Length<T> &);
 template <typename Length>
 std::ostream &operator<<(std::ostream &, const Label<Length> &);
 template <typename Length>

--- a/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
+++ b/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
@@ -293,7 +293,7 @@ MaybeConnection<Length> IntervalExchangeTransformation<Length>::induce(int limit
       c.top = til;  // NOTE: do not use ti.label here (see above)
       c.bottom = bi.label;
       c.addedIET = std::make_unique<IntervalExchangeTransformation<Length>>(std::move(r.value()));
-      return c;
+      return std::move(c);
     } else {
       NonSeparatingConnection<Length> c;
       c.top = til;  // NOTE: do not use ti.label here (see above)

--- a/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
+++ b/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
@@ -42,8 +42,8 @@
 #include <boost/range/adaptor/transformed.hpp>
 
 #include "intervalxt/interval_exchange_transformation.hpp"
-#include "intervalxt/maybe_saddle_connection.hpp"
 #include "intervalxt/label.hpp"
+#include "intervalxt/maybe_saddle_connection.hpp"
 
 namespace intervalxt {
 namespace {

--- a/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
+++ b/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
@@ -61,6 +61,7 @@ std::valarray<T> wedge(std::valarray<T> v1, std::valarray<T> v2) {
     throw std::logic_error("vectors must have same size");
 
   size_t d = v1.size();
+  assert(d);
   std::valarray<T> res(d * (d - 1) / 2);
   size_t k = 0;
   for (size_t i = 0; i < d - 1; i++)
@@ -278,26 +279,28 @@ MaybeConnection<Length> IntervalExchangeTransformation<Length>::induce(int limit
     // 1. merge the labels on top and bottom (by removing the one on top)
     impl->top.erase(impl->top.begin());
     impl->bottom.insert(ti.twin, bi);
+    auto x = bi.label;
     impl->bottom.erase(impl->bottom.begin());
-
-    // NOTE: we copy the top label since this is deleted below
-    const Label til = ti.label;
-
     impl->bottom.erase(ti.twin);
+
+    // NOTE: we copy the labels since we delete ti.label now and reduce might delete bi
+    const Label til = ti.label;
+    const Label bil = bi.label;
+
     impl->labels.erase(ti.label);
 
     // 2. check for reduceness after the merge
     auto r = impl->reduce();
     if (r) {
       SeparatingConnection<Length> c;
-      c.top = til;  // NOTE: do not use ti.label here (see above)
-      c.bottom = bi.label;
+      c.top = til;
+      c.bottom = bil;
       c.addedIET = std::make_unique<IntervalExchangeTransformation<Length>>(std::move(r.value()));
       return std::move(c);
     } else {
       NonSeparatingConnection<Length> c;
-      c.top = til;  // NOTE: do not use ti.label here (see above)
-      c.bottom = bi.label;
+      c.top = til;
+      c.bottom = bil;
       return c;
     }
   } else if (impl->boshernitzanMinimal()) {

--- a/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
+++ b/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
@@ -42,6 +42,8 @@
 #include <boost/range/adaptor/transformed.hpp>
 
 #include "intervalxt/interval_exchange_transformation.hpp"
+#include "intervalxt/maybe_saddle_connection.hpp"
+#include "intervalxt/label.hpp"
 
 namespace intervalxt {
 namespace {

--- a/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
+++ b/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
@@ -61,8 +61,8 @@ std::valarray<T> wedge(std::valarray<T> v1, std::valarray<T> v2) {
     throw std::logic_error("vectors must have same size");
 
   size_t d = v1.size();
-  assert(d);
   std::valarray<T> res(d * (d - 1) / 2);
+  if (d == 0) return res;
   size_t k = 0;
   for (size_t i = 0; i < d - 1; i++)
     for (size_t j = i + 1; j < d; j++) {

--- a/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
+++ b/libintervalxt/src/intervalxt/detail/interval_exchange_transformation.ipp
@@ -182,10 +182,10 @@ class IntervalExchangeTransformation<Length>::Implementation {
     if (ibottom->label == itop->label) {
       // Zorich acceleration step (= perform m full Dehn twists)
       auto m = itop->label.length() / length_to_subtract;
+      itop->label.length() -= m * length_to_subtract;
 
-      for (auto b = bottom.begin(); b != ibottom; ++b) {
-        itop->label.length() -= m * b->label.length();
-      }
+      // if it gets zero, cancel the last step
+      if (!itop->label.length()) itop->label.length() = length_to_subtract;
 
       // recompute from what is left
       ibottom = bottom.begin();
@@ -244,6 +244,66 @@ class IntervalExchangeTransformation<Length>::Implementation {
     return false;
   }
 };
+
+template <typename Length>
+MaybeConnection<Length> IntervalExchangeTransformation<Length>::induce(int limit) {
+  using Label = typename IntervalExchangeTransformation<Length>::Label;
+
+  int test;
+  for (int i = 0; i < limit; i++) {
+    test = impl->zorichInduction();
+    if (test) break;
+
+    std::swap(impl->top, impl->bottom);
+    test = impl->zorichInduction();
+    std::swap(impl->top, impl->bottom);
+    if (test) break;
+  }
+
+  const Interval<Length> ti = *(impl->top.begin());
+  const Interval<Length> bi = *(impl->bottom.begin());
+
+  if (ti.twin->label == bi.label) {
+    // Found a cylinder
+    Cylinder<Length> cyl;
+    cyl.label = ti.label;
+    impl->top.erase(impl->top.begin());
+    impl->bottom.erase(impl->bottom.begin());
+    impl->labels.erase(ti.label);
+    return cyl;
+  } else if (ti.label.length() == bi.label.length()) {
+    // Found a saddle connection
+    // 1. merge the labels on top and bottom (by removing the one on top)
+    impl->top.erase(impl->top.begin());
+    impl->bottom.insert(ti.twin, bi);
+    impl->bottom.erase(impl->bottom.begin());
+
+    // NOTE: we copy the top label since this is deleted below
+    const Label til = ti.label;
+
+    impl->bottom.erase(ti.twin);
+    impl->labels.erase(ti.label);
+
+    // 2. check for reduceness after the merge
+    auto r = impl->reduce();
+    if (r) {
+      SeparatingConnection<Length> c;
+      c.top = til;  // NOTE: do not use ti.label here (see above)
+      c.bottom = bi.label;
+      c.addedIET = std::make_unique<IntervalExchangeTransformation<Length>>(std::move(r.value()));
+      return c;
+    } else {
+      NonSeparatingConnection<Length> c;
+      c.top = til;  // NOTE: do not use ti.label here (see above)
+      c.bottom = bi.label;
+      return c;
+    }
+  } else if (impl->boshernitzanMinimal()) {
+    auto m = MinimalityGuarantee();
+    return m;
+  }
+  return {};
+}
 
 template <typename Length>
 IntervalExchangeTransformation<Length>::IntervalExchangeTransformation(const std::vector<Label>& top, const std::vector<size_t>& bottom) : impl(spimpl::make_unique_impl<Implementation>(top, [&]() {

--- a/libintervalxt/src/intervalxt/forward.hpp
+++ b/libintervalxt/src/intervalxt/forward.hpp
@@ -23,12 +23,14 @@
 #ifndef LIBINTERVALXT_FORWARD_HPP
 #define LIBINTERVALXT_FORWARD_HPP
 
-#include <gmpxx.h>
+#include <optional>
+#include <variant>
+
 #include "intervalxt/intervalxt.hpp"
 
 namespace intervalxt {
 
-template <typename T, typename Quo = std::conditional_t<std::is_integral_v<T>, T, mpz_class>>
+template <typename T>
 class Length;
 
 template <typename Length>
@@ -36,6 +38,24 @@ class Label;
 
 template <typename Length>
 class IntervalExchangeTransformation;
+
+struct MinimalityGuarantee;
+
+template <typename Length>
+struct Cylinder;
+
+template <typename Length>
+struct NonSeparatingConnection;
+
+template <typename Length>
+struct SeparatingConnection;
+
+template <typename Length>
+using MaybeConnection = std::optional<std::variant<
+  MinimalityGuarantee,
+  Cylinder<Length>,
+  NonSeparatingConnection<Length>,
+  SeparatingConnection<Length>>>;
 
 }  // namespace intervalxt
 

--- a/libintervalxt/src/intervalxt/forward.hpp
+++ b/libintervalxt/src/intervalxt/forward.hpp
@@ -52,10 +52,10 @@ struct SeparatingConnection;
 
 template <typename Length>
 using MaybeConnection = std::optional<std::variant<
-  MinimalityGuarantee,
-  Cylinder<Length>,
-  NonSeparatingConnection<Length>,
-  SeparatingConnection<Length>>>;
+    MinimalityGuarantee,
+    Cylinder<Length>,
+    NonSeparatingConnection<Length>,
+    SeparatingConnection<Length>>>;
 
 }  // namespace intervalxt
 

--- a/libintervalxt/src/intervalxt/interval_exchange_transformation.hpp
+++ b/libintervalxt/src/intervalxt/interval_exchange_transformation.hpp
@@ -31,7 +31,6 @@
 #include "external/spimpl/spimpl.h"
 
 #include "intervalxt/forward.hpp"
-#include "intervalxt/maybe_saddle_connection.hpp"
 
 namespace intervalxt {
 

--- a/libintervalxt/src/intervalxt/length.hpp
+++ b/libintervalxt/src/intervalxt/length.hpp
@@ -30,11 +30,14 @@
 
 namespace intervalxt {
 
+template <typename T>
+using LengthQuotient = std::conditional_t<std::is_integral_v<T>, T, mpz_class>;
+
 // A sample implementation of a length of a vector in ℝ² as a simple T.
-template <typename T, typename Quo>
-class Length : boost::totally_ordered<Length<T, Quo>>, boost::additive<Length<T, Quo>>, boost::multipliable<Length<T, Quo>, Quo> {
+template <typename T>
+class Length : boost::totally_ordered<Length<T>>, boost::additive<Length<T>>, boost::multipliable<Length<T>, LengthQuotient<T>> {
  public:
-  using Quotient = Quo;
+  using Quotient = LengthQuotient<T>;
   // Ideally coefficient should only be mpz_class and the interval exchange
   // transformation keeps track of a common denominator, see https://github.com/flatsurf/intervalxt/issues/48
   using Coefficient = mpq_class;
@@ -62,8 +65,8 @@ class Length : boost::totally_ordered<Length<T, Quo>>, boost::additive<Length<T,
 
   T squared() const;
 
-  template <typename C, typename Q>
-  friend std::ostream& operator<<(std::ostream&, const Length<C, Q>&);
+  template <typename C>
+  friend std::ostream& operator<<(std::ostream&, const Length<C>&);
 
   const T& length() const;
 

--- a/libintervalxt/src/intervalxt/maybe_saddle_connection.hpp
+++ b/libintervalxt/src/intervalxt/maybe_saddle_connection.hpp
@@ -22,11 +22,11 @@
 #define LIBINTERVALXT_MAYBE_SADDLE_CONNECTION_HPP
 
 #include <memory>
-#include <optional>
 #include <utility>
-#include <variant>
 
 #include "intervalxt/forward.hpp"
+
+#include "intervalxt/label.hpp"
 
 namespace intervalxt {
 
@@ -53,9 +53,6 @@ struct SeparatingConnection {
   std::unique_ptr<IntervalExchangeTransformation<Length>> addedIET;
   Label<Length> bottom, top;
 };
-
-template <typename Length>
-using MaybeConnection = std::optional<std::variant<MinimalityGuarantee, Cylinder<Length>, NonSeparatingConnection<Length>, SeparatingConnection<Length>>>;
 
 }  // namespace intervalxt
 

--- a/libintervalxt/src/length.cc
+++ b/libintervalxt/src/length.cc
@@ -28,17 +28,17 @@
 #include "intervalxt/length.hpp"
 
 namespace intervalxt {
-template <typename T, typename Quo>
-Length<T, Quo>::Length() : Length(T(0)) {}
+template <typename T>
+Length<T>::Length() : Length(T(0)) {}
 
-template <typename T, typename Quo>
-Length<T, Quo>::Length(const T& value) : value(value) {
+template <typename T>
+Length<T>::Length(const T& value) : value(value) {
   assert(value >= 0 && "a length cannot be negative");
 }
 
-template <typename T, typename Quo>
+template <typename T>
 template <bool enable, std::enable_if_t<enable, int>>
-Length<T, Quo>::Length(const std::string& s) {
+Length<T>::Length(const std::string& s) {
   if constexpr (std::is_integral_v<T>) {
     value = std::stoi(s);
   } else if constexpr (std::is_same_v<T, mpz_class> || std::is_same_v<T, mpq_class>) {
@@ -47,29 +47,29 @@ Length<T, Quo>::Length(const std::string& s) {
   assert(value >= 0 && "a length cannot be negative");
 }
 
-template <typename T, typename Quo>
-Length<T, Quo>& Length<T, Quo>::operator+=(const Length<T, Quo>& rhs) noexcept {
+template <typename T>
+Length<T>& Length<T>::operator+=(const Length<T>& rhs) noexcept {
   value += rhs.value;
   assert(value >= 0 && "a length cannot be negative");
   return *this;
 }
 
-template <typename T, typename Quo>
-Length<T, Quo>& Length<T, Quo>::operator-=(const Length<T, Quo>& rhs) noexcept {
+template <typename T>
+Length<T>& Length<T>::operator-=(const Length<T>& rhs) noexcept {
   value -= rhs.value;
   assert(value >= 0 && "a length cannot be negative");
   return *this;
 }
 
-template <typename T, typename Quo>
-Length<T, Quo>& Length<T, Quo>::operator*=(const Length<T, Quo>::Quotient& rhs) noexcept {
+template <typename T>
+Length<T>& Length<T>::operator*=(const Length<T>::Quotient& rhs) noexcept {
   value *= rhs;
   assert(value >= 0 && "a length cannot be negative");
   return *this;
 }
 
-template <typename T, typename Quo>
-typename Length<T, Quo>::Quotient Length<T, Quo>::operator/(const Length<T, Quo>& rhs) {
+template <typename T>
+typename Length<T>::Quotient Length<T>::operator/(const Length<T>& rhs) {
   assert(static_cast<bool>(rhs) && "cannot divide by zero vector");
   if constexpr (std::is_integral_v<T> || std::is_same_v<T, mpz_class>) {
     return value / rhs.value;
@@ -85,13 +85,13 @@ typename Length<T, Quo>::Quotient Length<T, Quo>::operator/(const Length<T, Quo>
   }
 }
 
-template <typename T, typename Quo>
-const T& Length<T, Quo>::length() const {
+template <typename T>
+const T& Length<T>::length() const {
   return value;
 }
 
-template <typename T, typename Quo>
-size_t Length<T, Quo>::degree() const {
+template <typename T>
+size_t Length<T>::degree() const {
   if constexpr (std::is_integral_v<T> || std::is_same_v<T, mpz_class> || std::is_same_v<T, mpq_class>) {
     return 1;
   } else if constexpr (std::is_same_v<T, eantic::renf_elem_class>) {
@@ -101,8 +101,8 @@ size_t Length<T, Quo>::degree() const {
   }
 }
 
-template <typename T, typename Quo>
-std::vector<typename Length<T, Quo>::Coefficient> Length<T, Quo>::coefficients() const {
+template <typename T>
+std::vector<typename Length<T>::Coefficient> Length<T>::coefficients() const {
   if constexpr (std::is_integral_v<T>) {
     std::vector<mpq_class> ret;
     if constexpr (std::is_same_v<T, long long>) {
@@ -129,30 +129,30 @@ std::vector<typename Length<T, Quo>::Coefficient> Length<T, Quo>::coefficients()
   }
 }
 
-template <typename T, typename Quo>
-T Length<T, Quo>::squared() const {
+template <typename T>
+T Length<T>::squared() const {
   auto ret = value * value;
   assert(ret >= value);
   return ret;
 }
 
-template <typename T, typename Quo>
-Length<T, Quo>::operator bool() const noexcept {
+template <typename T>
+Length<T>::operator bool() const noexcept {
   return static_cast<bool>(value);
 }
 
-template <typename T, typename Quo>
-bool Length<T, Quo>::operator<(const Length<T, Quo>& rhs) const noexcept {
+template <typename T>
+bool Length<T>::operator<(const Length<T>& rhs) const noexcept {
   return value < rhs.value;
 }
 
-template <typename T, typename Quo>
-bool Length<T, Quo>::operator==(const Length<T, Quo>& rhs) const noexcept {
+template <typename T>
+bool Length<T>::operator==(const Length<T>& rhs) const noexcept {
   return value == rhs.value;
 }
 
-template <typename T, typename Quo>
-std::ostream& operator<<(std::ostream& os, const Length<T, Quo>& self) {
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const Length<T>& self) {
   return os << self.value;
 }
 }  // namespace intervalxt

--- a/libintervalxt/test/induction.test.cc
+++ b/libintervalxt/test/induction.test.cc
@@ -22,9 +22,10 @@
 #include <boost/lexical_cast.hpp>
 #include <vector>
 
-#include <intervalxt/interval_exchange_transformation.hpp>
-#include <intervalxt/label.hpp>
 #include <intervalxt/length.hpp>
+#include <intervalxt/label.hpp>
+#include <intervalxt/interval_exchange_transformation.hpp>
+#include <intervalxt/maybe_saddle_connection.hpp>
 
 using namespace intervalxt;
 

--- a/libintervalxt/test/induction.test.cc
+++ b/libintervalxt/test/induction.test.cc
@@ -45,7 +45,29 @@ TEST(InductionTest, Induction2) {
   IntervalExchangeTransformation<Length> iet({Length(23), Length(5)}, {1, 0});
 
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length(23 - 4 * 5), Length(5)}, {1, 0}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(23 - 4 * 5), Length(5)}, {1, 0}));
+}
+
+TEST(InductionTest, Induction3) {
+  using Length = Length<int>;
+
+  IntervalExchangeTransformation<Length> iet({Length(13), Length(1)}, {1, 0});
+  iet.zorichInduction();
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(1), Length(1)}, {1, 0}));
+}
+
+TEST(InductionTest, Induction4) {
+  using Length = Length<int>;
+  using Label = Label<Length>;
+
+  // 0 3 1 2
+  // 1 2 0 3
+  Label l0(15), l1(2), l2(3), l3(7);
+  IntervalExchangeTransformation<Length> iet({l0, l3, l1, l2}, {l1, l2, l0, l3});
+  iet.zorichInduction();
+  EXPECT_EQ(iet.top(), std::vector<Label>({l0, l3, l1, l2}));
+  EXPECT_EQ(iet.bottom(), std::vector<Label>({l2, l1, l0, l3}));
+  EXPECT_EQ(iet.top().begin()->length(), 3);
 }
 
 TEST(InductionTest, InductionMpzClass) {
@@ -54,7 +76,7 @@ TEST(InductionTest, InductionMpzClass) {
   IntervalExchangeTransformation<Length> iet({Length("14328748557375491835455123393141239398243"), Length("51123145748597134")}, {1, 0});
 
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length("15560595195676063"), Length("51123145748597134")}, {1, 0}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length("15560595195676063"), Length("51123145748597134")}, {1, 0}));
 }
 
 TEST(InductionTest, InductionMpqClass) {
@@ -63,7 +85,7 @@ TEST(InductionTest, InductionMpqClass) {
   IntervalExchangeTransformation<Length> iet({Length("3/5"), Length("1/4")}, {1, 0});
 
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length("1/10"), Length("1/4")}, {1, 0}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length("1/10"), Length("1/4")}, {1, 0}));
 }
 
 TEST(InductionTest, InductionRenfElemClass) {
@@ -77,7 +99,7 @@ TEST(InductionTest, InductionRenfElemClass) {
   IntervalExchangeTransformation<Length> iet({Length(a), Length(b)}, {1, 0});
 
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length(a - 1), Length(b)}, {1, 0}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(a - 1), Length(b)}, {1, 0}));
 }
 
 TEST(InductionTest, Induction5) {
@@ -86,27 +108,125 @@ TEST(InductionTest, Induction5) {
   IntervalExchangeTransformation<Length> iet({Length(977), Length(351), Length(143), Length(321), Length(12)}, {3, 2, 0, 4, 1});
 
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length(49), Length(351), Length(143), Length(321), Length(12)}, {3, 2, 0, 4, 1}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(49), Length(351), Length(143), Length(321), Length(12)}, {3, 2, 0, 4, 1}));
 
   iet.swap();
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length(272), Length(143), Length(49), Length(12), Length(351)}, {4, 1, 2, 0, 3}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(272), Length(143), Length(49), Length(12), Length(351)}, {4, 1, 2, 0, 3}));
 
   iet.swap();
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length(79), Length(143), Length(49), Length(272), Length(12)}, {1, 2, 4, 3, 0}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(79), Length(143), Length(49), Length(272), Length(12)}, {1, 2, 4, 3, 0}));
 
   iet.swap();
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length(64), Length(49), Length(12), Length(272), Length(79)}, {4, 0, 1, 3, 2}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(64), Length(49), Length(12), Length(272), Length(79)}, {4, 0, 1, 3, 2}));
 
   iet.swap();
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length(15), Length(64), Length(49), Length(272), Length(12)}, {2, 4, 3, 1, 0}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(15), Length(64), Length(49), Length(272), Length(12)}, {2, 4, 3, 1, 0}));
 
   iet.swap();
   iet.zorichInduction();
-  EXPECT_EQ(IntervalExchangeTransformation<Length>({Length(34), Length(12), Length(272), Length(64), Length(15)}, {3, 4, 0, 2, 1}), iet);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(34), Length(12), Length(272), Length(64), Length(15)}, {3, 4, 0, 2, 1}));
+}
+
+TEST(InductionTest, InductionAndReport1) {
+  using Length = Length<int>;
+
+  IntervalExchangeTransformation<Length> iet({Length(1), Length(2), Length(3)}, {2, 1, 0});
+  EXPECT_FALSE(iet.induce(0));
+}
+
+TEST(InductionTest, InductionAndReport2) {
+  using Length = Length<int>;
+  using Label = Label<Length>;
+
+  Label l0(1), l1(1), l2(1);
+  IntervalExchangeTransformation<Length> iet({l0, l1, l2}, {l0, l2, l1});
+  auto r = iet.induce(0);
+  EXPECT_TRUE(r);
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(1), Length(1)}, {1, 0}));
+
+  EXPECT_TRUE(std::holds_alternative<Cylinder<Length>>(r.value()));
+  auto u = &std::get<Cylinder<Length>>(r.value());
+  EXPECT_EQ(u->label, l0);
+}
+
+TEST(InductionTest, InductionAndReport3) {
+  using Length = Length<int>;
+  using Label = Label<Length>;
+
+  Label l0(1), l1(1), l2(1);
+  IntervalExchangeTransformation<Length> iet({l0, l1, l2}, {l2, l1, l0});
+
+  auto r = iet.induce(0);
+
+  EXPECT_TRUE(r);
+  EXPECT_TRUE(std::holds_alternative<SeparatingConnection<Length>>(r.value()));
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(1)}, std::vector<unsigned long>({0})));
+
+  auto u = &std::get<SeparatingConnection<Length>>(r.value());
+
+  EXPECT_EQ(u->top, l0);
+  EXPECT_EQ(u->bottom, l2);
+  EXPECT_EQ(*(u->addedIET), IntervalExchangeTransformation<Length>({Length(1)}, std::vector<unsigned long>({0})));
+}
+
+TEST(InductionTest, InductionAndReport4) {
+  using Length = Length<int>;
+  using Label = Label<Length>;
+
+  // 0 1 2 3 4 5
+  // 3 2 1 5 4 0
+  // ->
+  // label 0 get dropped and we have the two iet
+  // 1 2  and  3 4 5
+  // 2 1       5 4 3
+  Label l0(1), l1(2), l2(3), l3(1), l4(5), l5(7);
+  IntervalExchangeTransformation<Length> iet({l0, l1, l2, l3, l4, l5}, {l3, l2, l1, l5, l4, l0});
+
+  auto r = iet.induce(0);
+
+  EXPECT_TRUE(r);
+  EXPECT_TRUE(std::holds_alternative<SeparatingConnection<Length>>(r.value()));
+  EXPECT_EQ(iet.top(), std::vector<Label>({l1, l2}));
+  EXPECT_EQ(iet.bottom(), std::vector<Label>({l2, l1}));
+
+  auto u = &std::get<SeparatingConnection<Length>>(r.value());
+  EXPECT_EQ(u->addedIET->top(), std::vector<Label>({l3, l4, l5}));
+  EXPECT_EQ(u->addedIET->bottom(), std::vector<Label>({l5, l4, l3}));
+}
+
+TEST(InductionTest, InductionAndReport5) {
+  using Length = Length<int>;
+  using Label = Label<Length>;
+
+  Label l0(1), l1(3), l2(1);
+  IntervalExchangeTransformation<Length> iet({l0, l1, l2}, {l2, l0, l1});
+  auto r = iet.induce(0);
+  EXPECT_TRUE(r);
+  EXPECT_TRUE(std::holds_alternative<NonSeparatingConnection<Length>>(r.value()));
+  EXPECT_EQ(iet, IntervalExchangeTransformation<Length>({Length(3), Length(1)}, {1, 0}));
+
+  auto u = &std::get<NonSeparatingConnection<Length>>(r.value());
+  EXPECT_EQ(u->top, l0);
+  EXPECT_EQ(u->bottom, l2);
+}
+
+TEST(InductionTest, InductionAndReport6) {
+  using Length = Length<int>;
+  using Label = Label<Length>;
+
+  Label l0(13);
+  Label l1(5);
+  IntervalExchangeTransformation<Length> iet({l0, l1}, {l1, l0});
+  auto r = iet.induce(0);
+  EXPECT_FALSE(r);
+  r = iet.induce(1);
+  EXPECT_FALSE(r);
+  r = iet.induce(1);
+  EXPECT_TRUE(r);
 }
 
 }  // namespace

--- a/libintervalxt/test/induction.test.cc
+++ b/libintervalxt/test/induction.test.cc
@@ -22,9 +22,9 @@
 #include <boost/lexical_cast.hpp>
 #include <vector>
 
-#include <intervalxt/length.hpp>
-#include <intervalxt/label.hpp>
 #include <intervalxt/interval_exchange_transformation.hpp>
+#include <intervalxt/label.hpp>
+#include <intervalxt/length.hpp>
 #include <intervalxt/maybe_saddle_connection.hpp>
 
 using namespace intervalxt;


### PR DESCRIPTION
Implement reduction. Boshernitzan minimality criterion is postponed (for now it simply returns `false` on all instances).