### PR TITLE
implement Sah-Arnoux-Fathi invariant

### DIFF
--- a/libintervalxt/src/intervalxt/cppyy.hpp
+++ b/libintervalxt/src/intervalxt/cppyy.hpp
@@ -28,13 +28,12 @@
 #include "intervalxt/length.hpp"
 
 namespace intervalxt {
-template <typename T>
-std::ostream &operator<<(std::ostream &, const Length<T> &);
-template <typename Coordinate>
-std::ostream &operator<<(std::ostream &, const IntervalExchangeTransformation<Coordinate> &);
+template <typename T, typename Q>
+std::ostream &operator<<(std::ostream &, const Length<T, Q> &);
+template <typename Length>
+std::ostream &operator<<(std::ostream &, const Label<Length> &);
+template <typename Length>
+std::ostream &operator<<(std::ostream &, const IntervalExchangeTransformation<Length> &);
 }  // namespace intervalxt
-
-extern template std::ostream &intervalxt::operator<<(std::ostream &, const IntervalExchangeTransformation<int> &);
-extern template std::ostream &intervalxt::operator<<(std::ostream &, const Length<int> &);
 
 #endif

--- a/libintervalxt/src/intervalxt/forward.hpp
+++ b/libintervalxt/src/intervalxt/forward.hpp
@@ -23,11 +23,12 @@
 #ifndef LIBINTERVALXT_FORWARD_HPP
 #define LIBINTERVALXT_FORWARD_HPP
 
+#include <gmpxx.h>
 #include "intervalxt/intervalxt.hpp"
 
 namespace intervalxt {
 
-template <typename T>
+template <typename T, typename Quo = std::conditional_t<std::is_integral_v<T>, T, mpz_class>>
 class Length;
 
 template <typename Length>

--- a/libintervalxt/src/intervalxt/interval_exchange_transformation.hpp
+++ b/libintervalxt/src/intervalxt/interval_exchange_transformation.hpp
@@ -26,6 +26,8 @@
 #include <optional>
 #include <vector>
 
+#include <gmpxx.h>
+
 #include "external/spimpl/spimpl.h"
 
 #include "intervalxt/forward.hpp"
@@ -51,6 +53,9 @@ class IntervalExchangeTransformation {
 
   // Swap the top and bottom intervals.
   void swap();
+
+  // Return the Sah-Arnoux-Fathi invariant
+  std::valarray<mpq_class> safInvariant() const;
 
   // Remove the first pair of intervals (assuming that it corresponds to a
   // cylinder, i.e., the leftmost singularity is a connection of length one).

--- a/libintervalxt/src/intervalxt/length.hpp
+++ b/libintervalxt/src/intervalxt/length.hpp
@@ -32,7 +32,7 @@ namespace intervalxt {
 
 // A sample implementation of a length of a vector in ℝ² as a simple T.
 template <typename T, typename Quo>
-class Length : boost::totally_ordered<Length<T>>, boost::additive<Length<T>>, boost::multipliable<Length<T>, Quo> {
+class Length : boost::totally_ordered<Length<T, Quo>>, boost::additive<Length<T, Quo>>, boost::multipliable<Length<T, Quo>, Quo> {
  public:
   using Quotient = Quo;
   // TODO: ideally coefficient should also be mpz_class and the interval exchange transformation

--- a/libintervalxt/src/intervalxt/length.hpp
+++ b/libintervalxt/src/intervalxt/length.hpp
@@ -31,10 +31,13 @@
 namespace intervalxt {
 
 // A sample implementation of a length of a vector in ℝ² as a simple T.
-template <typename T>
-class Length : boost::totally_ordered<Length<T>>, boost::additive<Length<T>>, boost::multipliable<Length<T>, mpz_class> {
+template <typename T, typename Quo>
+class Length : boost::totally_ordered<Length<T>>, boost::additive<Length<T>>, boost::multipliable<Length<T>, Quo> {
  public:
-  using Quotient = mpz_class;
+  using Quotient = Quo;
+  // TODO: ideally coefficient should also be mpz_class and the interval exchange transformation
+  // should store a mpz_class denominator
+  using Coefficient = mpq_class;
 
   Length();
   Length(const T&);
@@ -50,13 +53,17 @@ class Length : boost::totally_ordered<Length<T>>, boost::additive<Length<T>>, bo
 
   explicit operator bool() const noexcept;
 
+  // Return the coefficients as a (fixed length) vector of integers (discarding the denominator)
+  size_t degree() const;
+  std::vector<Coefficient> coefficients() const;
+
   // Return the floor of the division of this length by the argument.
   Quotient operator/(const Length&);
 
   T squared() const;
 
-  template <typename C>
-  friend std::ostream& operator<<(std::ostream&, const Length<C>&);
+  template <typename C, typename Q>
+  friend std::ostream& operator<<(std::ostream&, const Length<C, Q>&);
 
   const T& length() const;
 

--- a/libintervalxt/src/intervalxt/length.hpp
+++ b/libintervalxt/src/intervalxt/length.hpp
@@ -35,8 +35,8 @@ template <typename T, typename Quo>
 class Length : boost::totally_ordered<Length<T, Quo>>, boost::additive<Length<T, Quo>>, boost::multipliable<Length<T, Quo>, Quo> {
  public:
   using Quotient = Quo;
-  // TODO: ideally coefficient should also be mpz_class and the interval exchange transformation
-  // should store a mpz_class denominator
+  // Ideally coefficient should only be mpz_class and the interval exchange
+  // transformation keeps track of a common denominator, see https://github.com/flatsurf/intervalxt/issues/48
   using Coefficient = mpq_class;
 
   Length();

--- a/libintervalxt/src/length.cc
+++ b/libintervalxt/src/length.cc
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <variant>
+#include <vector>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/numeric/conversion/cast.hpp>
@@ -27,17 +28,17 @@
 #include "intervalxt/length.hpp"
 
 namespace intervalxt {
-template <typename T>
-Length<T>::Length() : Length(T(0)) {}
+template <typename T, typename Quo>
+Length<T, Quo>::Length() : Length(T(0)) {}
 
-template <typename T>
-Length<T>::Length(const T& value) : value(value) {
+template <typename T, typename Quo>
+Length<T, Quo>::Length(const T& value) : value(value) {
   assert(value >= 0 && "a length cannot be negative");
 }
 
-template <typename T>
+template <typename T, typename Quo>
 template <bool enable, std::enable_if_t<enable, int>>
-Length<T>::Length(const std::string& s) {
+Length<T, Quo>::Length(const std::string& s) {
   if constexpr (std::is_integral_v<T>) {
     value = std::stoi(s);
   } else if constexpr (std::is_same_v<T, mpz_class> || std::is_same_v<T, mpq_class>) {
@@ -46,44 +47,32 @@ Length<T>::Length(const std::string& s) {
   assert(value >= 0 && "a length cannot be negative");
 }
 
-template <typename T>
-Length<T>& Length<T>::operator+=(const Length<T>& rhs) noexcept {
+template <typename T, typename Quo>
+Length<T, Quo>& Length<T, Quo>::operator+=(const Length<T, Quo>& rhs) noexcept {
   value += rhs.value;
   assert(value >= 0 && "a length cannot be negative");
   return *this;
 }
 
-template <typename T>
-Length<T>& Length<T>::operator-=(const Length<T>& rhs) noexcept {
+template <typename T, typename Quo>
+Length<T, Quo>& Length<T, Quo>::operator-=(const Length<T, Quo>& rhs) noexcept {
   value -= rhs.value;
   assert(value >= 0 && "a length cannot be negative");
   return *this;
 }
 
-template <typename T>
-Length<T>& Length<T>::operator*=(const mpz_class& rhs) noexcept {
-  if constexpr (std::is_integral_v<T>) {
-    assert(rhs.fits_sint_p());
-    value *= boost::numeric_cast<T>(rhs.get_si());
-  } else {
-    value *= rhs;
-  }
+template <typename T, typename Quo>
+Length<T, Quo>& Length<T, Quo>::operator*=(const Length<T, Quo>::Quotient& rhs) noexcept {
+  value *= rhs;
+  assert(value >= 0 && "a length cannot be negative");
   return *this;
 }
 
-template <typename T>
-mpz_class Length<T>::operator/(const Length<T>& rhs) {
+template <typename T, typename Quo>
+typename Length<T, Quo>::Quotient Length<T, Quo>::operator/(const Length<T, Quo>& rhs) {
   assert(static_cast<bool>(rhs) && "cannot divide by zero vector");
-  if constexpr (std::is_integral_v<T>) {
-    auto ret = value / rhs.value;
-    if constexpr (std::is_same_v<T, long long>) {
-      return mpz_class(boost::lexical_cast<std::string>(ret));
-    } else {
-      return ret;
-    }
-  } else if constexpr (std::is_same_v<T, mpz_class>) {
-    mpz_class ret = value / rhs.value;
-    return ret;
+  if constexpr (std::is_integral_v<T> || std::is_same_v<T, mpz_class>) {
+    return value / rhs.value;
   } else if constexpr (std::is_same_v<T, mpq_class>) {
     // NOTE: floor division could be smarter than that!
     mpz_class ret = (value.get_num() * rhs.value.get_den()) / (value.get_den() * rhs.value.get_num());
@@ -96,35 +85,74 @@ mpz_class Length<T>::operator/(const Length<T>& rhs) {
   }
 }
 
-template <typename T>
-const T& Length<T>::length() const {
+template <typename T, typename Quo>
+const T& Length<T, Quo>::length() const {
   return value;
 }
 
-template <typename T>
-T Length<T>::squared() const {
+template <typename T, typename Quo>
+size_t Length<T, Quo>::degree() const {
+  if constexpr (std::is_integral_v<T> || std::is_same_v<T, mpz_class> || std::is_same_v<T, mpq_class>) {
+    return 1;
+  } else if constexpr (std::is_same_v<T, eantic::renf_elem_class>) {
+    return value.parent()->degree();
+  } else {
+    throw std::logic_error("not implemented: no degree for this type");
+  }
+}
+
+template <typename T, typename Quo>
+std::vector<typename Length<T, Quo>::Coefficient> Length<T, Quo>::coefficients() const {
+  if constexpr (std::is_integral_v<T>) {
+    std::vector<mpq_class> ret;
+    if constexpr (std::is_same_v<T, long long>) {
+      ret.push_back(mpq_class(boost::lexical_cast<std::string>(value)));
+    } else {
+      ret.push_back(value);
+    }
+    return ret;
+  } else if constexpr (std::is_same_v<T, mpz_class> || std::is_same_v<T, mpq_class>) {
+    std::vector<mpq_class> ret;
+    ret.push_back(value);
+    return ret;
+  } else if constexpr (std::is_same_v<T, eantic::renf_elem_class>) {
+    std::vector<mpq_class> ret;
+    auto d = value.den();
+    for (auto i : value.num_vector()) {
+      auto dat = mpq_class(i, d);
+      dat.canonicalize();
+      ret.push_back(dat);
+    }
+    return ret;
+  } else {
+    throw std::logic_error("not implemented; coefficient for non-integral types");
+  }
+}
+
+template <typename T, typename Quo>
+T Length<T, Quo>::squared() const {
   auto ret = value * value;
   assert(ret >= value);
   return ret;
 }
 
-template <typename T>
-Length<T>::operator bool() const noexcept {
+template <typename T, typename Quo>
+Length<T, Quo>::operator bool() const noexcept {
   return static_cast<bool>(value);
 }
 
-template <typename T>
-bool Length<T>::operator<(const Length<T>& rhs) const noexcept {
+template <typename T, typename Quo>
+bool Length<T, Quo>::operator<(const Length<T, Quo>& rhs) const noexcept {
   return value < rhs.value;
 }
 
-template <typename T>
-bool Length<T>::operator==(const Length<T>& rhs) const noexcept {
+template <typename T, typename Quo>
+bool Length<T, Quo>::operator==(const Length<T, Quo>& rhs) const noexcept {
   return value == rhs.value;
 }
 
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const Length<T>& self) {
+template <typename T, typename Quo>
+std::ostream& operator<<(std::ostream& os, const Length<T, Quo>& self) {
   return os << self.value;
 }
 }  // namespace intervalxt

--- a/libintervalxt/test/.gitignore
+++ b/libintervalxt/test/.gitignore
@@ -36,6 +36,7 @@
 /interval_exchange_transformation
 /rational_linear_subspace
 /cereal
+/saf
 
 ### Autotools Generated Files
 /.deps

--- a/libintervalxt/test/Makefile.am
+++ b/libintervalxt/test/Makefile.am
@@ -1,10 +1,11 @@
 if HAVE_GOOGLETEST
-  check_PROGRAMS = rational_linear_subspace interval_exchange_transformation induction induction_benchmark cereal
+  check_PROGRAMS = rational_linear_subspace interval_exchange_transformation induction saf induction_benchmark cereal
   TESTS = $(check_PROGRAMS)
 endif
 
 interval_exchange_transformation_SOURCES = interval_exchange_transformation.test.cc main.hpp
 induction_SOURCES = induction.test.cc main.hpp
+saf_SOURCES = saf.test.cc main.hpp
 induction_benchmark_SOURCES = induction.benchmark.cc main.hpp
 rational_linear_subspace_SOURCES = rational_linear_subspace.test.cc main.hpp
 cereal_SOURCES = cereal.test.cc main.hpp

--- a/libintervalxt/test/saf.test.cc
+++ b/libintervalxt/test/saf.test.cc
@@ -46,14 +46,18 @@ TEST(IETTest, NonZeroSAF1) {
   std::valarray<mpq_class> v = iet.safInvariant();
   EXPECT_TRUE(v.min() != 0 || v.max() != 0);
 
-  int sign = -1;
+  int sign = 1;
 
   for (int i = 0; i < 10; i++) {
     iet.zorichInduction();
     iet.swap();
-    std::valarray<mpq_class> vv = sign * iet.safInvariant();
+    std::valarray<mpq_class> vv;
+    if (sign)
+      vv = -iet.safInvariant();
+    else
+      vv = iet.safInvariant();
     EXPECT_TRUE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
-    sign *= -1;
+    sign ^= 1;
   }
 }
 
@@ -68,14 +72,18 @@ TEST(IETTest, NonZeroSAF2) {
   std::valarray<mpq_class> v = iet.safInvariant();
   EXPECT_TRUE(v.min() != 0 || v.max() != 0);
 
-  int sign = -1;
+  int sign = 1;
 
   for (int i = 0; i < 10; i++) {
     iet.zorichInduction();
     iet.swap();
-    std::valarray<mpq_class> vv = sign * iet.safInvariant();
+    std::valarray<mpq_class> vv;
+    if (sign)
+      vv = -iet.safInvariant();
+    else
+      vv = iet.safInvariant();
     EXPECT_TRUE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
-    sign *= -1;
+    sign ^= 1;
   }
 }
 

--- a/libintervalxt/test/saf.test.cc
+++ b/libintervalxt/test/saf.test.cc
@@ -1,0 +1,126 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2019 Vincent Delecroix
+ *        Copyright (C) 2019 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include <intervalxt/interval_exchange_transformation.hpp>
+#include <intervalxt/label.hpp>
+#include <intervalxt/length.hpp>
+
+using namespace intervalxt;
+using std::vector;
+
+TEST(IETTest, SAFRational) {
+  using Length = Length<int>;
+  IntervalExchangeTransformation<Length> iet({Length(18), Length(3), Length(1), Length(1)}, {3, 0, 1, 2});
+  std::valarray<mpq_class> v = iet.safInvariant();
+}
+
+TEST(IETTest, NonZeroSAF1) {
+  using Length = Length<eantic::renf_elem_class>;
+
+  auto K = eantic::renf_class::make("a^3 - 2*a^2 - 3*a - 1", "a", "3.07 +/- 0.01");
+  auto a = K->gen();
+  auto one = K->one();
+
+  IntervalExchangeTransformation<Length> iet({Length(a / 2), Length(a * a - mpq_class(1, 13)), Length(4 * a / 7 - 1), Length(2 * one)}, {3, 2, 1, 0});
+
+  std::valarray<mpq_class> v = iet.safInvariant();
+  EXPECT_TRUE(v.min() != 0 || v.max() != 0);
+
+  int sign = -1;
+
+  for (int i = 0; i < 10; i++) {
+    iet.zorichInduction();
+    iet.swap();
+    std::valarray<mpq_class> vv = sign * iet.safInvariant();
+    EXPECT_TRUE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
+    sign *= -1;
+  }
+}
+
+TEST(IETTest, NonZeroSAF2) {
+  using Length = Length<eantic::renf_elem_class>;
+
+  auto K = eantic::renf_class::make("5*a^3 - 2*a^2 - 3*a - 13", "a", "1.68 +/- 0.01");
+  auto a = K->gen();
+  auto one = K->one();
+
+  IntervalExchangeTransformation<Length> iet({Length(2 * a / 17), Length(5 * a * a / 3 - mpq_class(1, 18)), Length(5 * a * a / 2 - 3), Length(3 * one)}, {3, 2, 1, 0});
+  std::valarray<mpq_class> v = iet.safInvariant();
+  EXPECT_TRUE(v.min() != 0 || v.max() != 0);
+
+  int sign = -1;
+
+  for (int i = 0; i < 10; i++) {
+    iet.zorichInduction();
+    iet.swap();
+    std::valarray<mpq_class> vv = sign * iet.safInvariant();
+    EXPECT_TRUE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
+    sign *= -1;
+  }
+}
+
+TEST(IETTest, SAFArnouxYoccoz3) {
+  using Length = Length<eantic::renf_elem_class>;
+
+  auto K = eantic::renf_class::make("a^3 - a^2 - a - 1", "a", "1.84 +/- 0.01");
+  auto a = K->gen();
+  auto one = K->one();
+
+  IntervalExchangeTransformation<Length> iet({Length(a + 1), Length(a * a - a - 1), Length(a * a), Length(a), Length(a), Length(one), Length(one)}, {1, 4, 3, 6, 5, 2, 0});
+  std::valarray<mpq_class> v = iet.safInvariant();
+  EXPECT_EQ(v.min(), mpq_class(0));
+  EXPECT_EQ(v.max(), mpq_class(0));
+
+  for (int i = 0; i < 10; i++) {
+    iet.zorichInduction();
+    iet.swap();
+    std::valarray<mpq_class> vv = iet.safInvariant();
+    EXPECT_TRUE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
+  }
+}
+
+TEST(IETTest, SAFArnouxYoccoz4) {
+  using Length = Length<eantic::renf_elem_class>;
+
+  auto K = eantic::renf_class::make("a^4 - a^3 - a^2 - a - 1", "a", "1.92 +/- 0.01");
+  auto a = K->gen();
+  auto one = K->one();
+
+  IntervalExchangeTransformation<Length> iet({Length(a.pow(4) - a.pow(3)),
+                                              Length(2 * a.pow(3) - a.pow(4)),
+                                              Length(a.pow(3)), Length(a.pow(2)), Length(a.pow(2)),
+                                              Length(a), Length(a), Length(one), Length(one)},
+                                             {1, 4, 3, 6, 5, 8, 7, 2, 0});
+  std::valarray<mpq_class> v = iet.safInvariant();
+  EXPECT_EQ(v.min(), mpq_class(0));
+  EXPECT_EQ(v.max(), mpq_class(0));
+
+  for (int i = 0; i < 10; i++) {
+    iet.zorichInduction();
+    iet.swap();
+    std::valarray<mpq_class> vv = iet.safInvariant();
+    EXPECT_TRUE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
+  }
+}
+
+#include "main.hpp"


### PR DESCRIPTION
This is basically ready to merge except that calling `safInvariant()` might lead to a segfault if the lengths belong to different number fields. The interval exchange constructor will not complain about that.