### PR TITLE
Support {fmt}

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ run
 ```
 conda config --add channels conda-forge
 conda config --add channels flatsurf # if you want to pull in the latest version of dependencies
-conda create -n intervalxt-build cxx-compiler libtool automake boost-cpp e-antic benchmark ccache ppl libexactreal pytest cppyy
+conda create -n intervalxt-build cxx-compiler libtool automake boost-cpp e-antic benchmark ccache ppl libexactreal pytest cppyy fmt
 conda activate intervalxt-build
 export CPPFLAGS="-isystem $CONDA_PREFIX/include"
 export CFLAGS="$CPPFLAGS"

--- a/libintervalxt/configure.ac
+++ b/libintervalxt/configure.ac
@@ -37,6 +37,11 @@ AC_LANG([C++])
 dnl We use some C++17 features, such as if constexpr
 AX_CXX_COMPILE_STDCXX(17)
 
+AC_CHECK_HEADERS([boost/type_traits.hpp], , AC_MSG_ERROR([boost headers not found]))
+
+AX_CXX_CHECK_LIB([fmt], [fmt::v6::getpagesize()], , AC_MSG_ERROR([fmt library not found]), [-lfmt])
+AC_CHECK_HEADERS([fmt/format.h], , AC_MSG_ERROR([fmt headers not found]))
+
 ACX_PTHREAD([], [AC_MSG_ERROR([pthread not supported])])
 
 dnl We use FLINT's fmpq_sub_si through renfxx.h

--- a/libintervalxt/intervalxt/fmt.hpp
+++ b/libintervalxt/intervalxt/fmt.hpp
@@ -1,0 +1,76 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+// Include this header to get {fmt} support for all types define by this library.
+
+// Note that we would have liked to give {fmt} first class support and deduce
+// ostream<< from this. However, this is not possible with the encapsulation
+// that we are presently using: Since a Formatter's format() is templatized, it
+// cannot be in a .cc file. Of course printing should not use any private
+// information that is not readily available otherwise, but we do not want
+// implementations in header files and also, this would mean that every header
+// has to pull in <fmt/core.h> or we'd need some other header scheme for this.
+
+#ifndef LIBINTERVALXT_FMT_HPP
+#define LIBINTERVALXT_FMT_HPP
+
+#include <fmt/core.h>
+
+#include <sstream>
+
+#include "length.hpp"
+
+namespace intervalxt {
+
+template <typename T>
+struct GenericFormatter {
+  constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const T& value, FormatContext& ctx) {
+    std::ostringstream ss;
+    ss << value;
+    return fmt::format_to(ctx.out(), "{}", ss.str());
+  }
+};
+
+}  // namespace intervalxt
+
+template <>
+struct fmt::formatter<::intervalxt::IntervalExchangeTransformation> : ::intervalxt::GenericFormatter<::intervalxt::IntervalExchangeTransformation> {};
+template <>
+struct fmt::formatter<::intervalxt::DynamicalDecomposition> : ::intervalxt::GenericFormatter<::intervalxt::DynamicalDecomposition> {};
+template <>
+struct fmt::formatter<::intervalxt::Component> : ::intervalxt::GenericFormatter<::intervalxt::Component> {};
+template <>
+struct fmt::formatter<::intervalxt::HalfEdge> : ::intervalxt::GenericFormatter<::intervalxt::HalfEdge> {};
+template <>
+struct fmt::formatter<::intervalxt::Separatrix> : ::intervalxt::GenericFormatter<::intervalxt::Separatrix> {};
+template <>
+struct fmt::formatter<::intervalxt::DecompositionStep> : ::intervalxt::GenericFormatter<::intervalxt::DecompositionStep> {};
+template <>
+struct fmt::formatter<::intervalxt::InductionStep> : ::intervalxt::GenericFormatter<::intervalxt::InductionStep> {};
+template <>
+struct fmt::formatter<::intervalxt::Connection> : ::intervalxt::GenericFormatter<::intervalxt::Connection> {};
+template <>
+struct fmt::formatter<::intervalxt::Side> : ::intervalxt::GenericFormatter<::intervalxt::Side> {};
+template <>
+struct fmt::formatter<::intervalxt::Length> : ::intervalxt::GenericFormatter<::intervalxt::Length> {};
+
+#endif

--- a/libintervalxt/intervalxt/sample/arithmetic.hpp
+++ b/libintervalxt/intervalxt/sample/arithmetic.hpp
@@ -25,7 +25,6 @@
 #include <vector>
 
 #include <gmpxx.h>
-#include <boost/lexical_cast.hpp>
 
 namespace intervalxt::sample {
 
@@ -38,7 +37,7 @@ struct Arithmetic {
 
   static std::vector<mpq_class> coefficients(const T& value) {
     if constexpr (std::is_same_v<T, long long> || std::is_same_v<T, unsigned long long>) {
-      return std::vector<mpq_class>{mpq_class(boost::lexical_cast<std::string>(value))};
+      return std::vector<mpq_class>{mpq_class(std::to_string(value))};
     } else {
       return std::vector<mpq_class>{value};
     }

--- a/libintervalxt/intervalxt/sample/detail/length.ipp
+++ b/libintervalxt/intervalxt/sample/detail/length.ipp
@@ -26,7 +26,6 @@
 #include <variant>
 #include <vector>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 
 #include "../external/gmpxxll/mpz_class.hpp"

--- a/libintervalxt/src/Makefile.am
+++ b/libintervalxt/src/Makefile.am
@@ -26,6 +26,7 @@ nobase_pkginclude_HEADERS =                                       \
 	../intervalxt/external/spimpl/spimpl.h                    \
 	../intervalxt/external/gmpxxll/mpz_class.hpp              \
 	../intervalxt/forward.hpp                                 \
+	../intervalxt/fmt.hpp                                     \
 	../intervalxt/half_edge.hpp                               \
 	../intervalxt/induction_step.hpp                          \
 	../intervalxt/interval_exchange_transformation.hpp        \

--- a/libintervalxt/src/component.cc
+++ b/libintervalxt/src/component.cc
@@ -23,14 +23,15 @@
 #include <variant>
 #include <vector>
 
-#include "external/rx-ranges/include/rx/ranges.hpp"
+#include <fmt/format.h>
 
-#include <boost/algorithm/string/join.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/logic/tribool.hpp>
+
+#include "external/rx-ranges/include/rx/ranges.hpp"
 
 #include "../intervalxt/component.hpp"
 #include "../intervalxt/decomposition_step.hpp"
+#include "../intervalxt/fmt.hpp"
 #include "../intervalxt/induction_step.hpp"
 #include "../intervalxt/label.hpp"
 
@@ -49,8 +50,6 @@ using std::begin;
 using std::end;
 using std::string;
 using std::vector;
-
-using boost::lexical_cast;
 
 using InductionResult = InductionStep::Result;
 using DecompositionResult = DecompositionStep::Result;
@@ -436,8 +435,7 @@ void Implementation<Component>::registerSeparating(Component& left, const Connec
 }
 
 std::ostream& operator<<(std::ostream& os, const Component& self) {
-  return os << boost::algorithm::join(
-             self.perimeter() | rx::transform([](const auto& side) { return lexical_cast<string>(side); }) | rx::to_vector(), " ");
+  return os << fmt::format("{}", fmt::join(self.perimeter(), " "));
 }
 
 std::ostream& operator<<(std::ostream& os, const Side& self) {

--- a/libintervalxt/src/dynamical_decomposition.cc
+++ b/libintervalxt/src/dynamical_decomposition.cc
@@ -21,13 +21,13 @@
 #include <ostream>
 #include <vector>
 
-#include <boost/algorithm/string/join.hpp>
-#include <boost/lexical_cast.hpp>
+#include <fmt/format.h>
 
 #include "external/rx-ranges/include/rx/ranges.hpp"
 
 #include "../intervalxt/component.hpp"
 #include "../intervalxt/dynamical_decomposition.hpp"
+#include "../intervalxt/fmt.hpp"
 #include "../intervalxt/interval_exchange_transformation.hpp"
 #include "../intervalxt/label.hpp"
 
@@ -39,9 +39,6 @@
 #include "util/assert.ipp"
 
 namespace intervalxt {
-
-using boost::lexical_cast;
-using std::string;
 
 DynamicalDecomposition::DynamicalDecomposition(const IntervalExchangeTransformation& iet) : impl(spimpl::make_unique_impl<Implementation>(iet)) {}
 
@@ -83,13 +80,8 @@ Component Implementation<DynamicalDecomposition>::createComponent(std::shared_pt
   return right;
 }
 
-std::string Implementation<DynamicalDecomposition>::render(std::shared_ptr<DecompositionState> decomposition, Label label) {
-  return Implementation<IntervalExchangeTransformation>::render(begin(decomposition->components)->iet, label);
-}
-
 std::ostream& operator<<(std::ostream& os, const DynamicalDecomposition& self) {
-  auto components = self.components();
-  return os << "DynamicalDecomposition(" << boost::algorithm::join(components | rx::transform([](const auto& component) { return lexical_cast<string>(component); }) | rx::to_vector(), ", ");
+  return os << fmt::format("DynamicalDecomposition({})", fmt::join(self.components(), ", "));
 }
 
 }  // namespace intervalxt

--- a/libintervalxt/src/half_edge.cc
+++ b/libintervalxt/src/half_edge.cc
@@ -138,7 +138,7 @@ Implementation<HalfEdge>::Implementation(std::shared_ptr<DecompositionState> dec
 ostream& operator<<(ostream& os, const HalfEdge& self) {
   if (self.impl->contour == Contour::TOP)
     os << "-";
-  return os << "[" << Implementation<DynamicalDecomposition>::render(self.impl->decomposition, self.impl->label) << "]";
+  return os << "[" << self.impl->decomposition->render(self.impl->label) << "]";
 }
 
 }  // namespace intervalxt

--- a/libintervalxt/src/impl/decomposition_state.hpp
+++ b/libintervalxt/src/impl/decomposition_state.hpp
@@ -54,6 +54,8 @@ struct DecompositionState {
 
   void check() const;
 
+  std::string render(Label) const;
+
   friend std::ostream& operator<<(std::ostream&, const DecompositionState&);
 };
 

--- a/libintervalxt/src/impl/dynamical_decomposition.impl.hpp
+++ b/libintervalxt/src/impl/dynamical_decomposition.impl.hpp
@@ -36,7 +36,6 @@ class Implementation<DynamicalDecomposition> {
 
   static Component createComponent(std::shared_ptr<DecompositionState>, Component& left, const Connection&, IntervalExchangeTransformation&& right);
   static Component createComponent(std::shared_ptr<DecompositionState>, IntervalExchangeTransformation&&);
-  static std::string render(std::shared_ptr<DecompositionState>, Label);
 
   std::shared_ptr<DecompositionState> decomposition;
 };

--- a/libintervalxt/src/interval_exchange_transformation.cc
+++ b/libintervalxt/src/interval_exchange_transformation.cc
@@ -23,13 +23,13 @@
 #include <unordered_set>
 #include <valarray>
 
-#include <gmpxx.h>
+#include <fmt/format.h>
 
-#include <boost/algorithm/string/join.hpp>
-#include <boost/lexical_cast.hpp>
+#include <gmpxx.h>
 
 #include "external/rx-ranges/include/rx/ranges.hpp"
 
+#include "../intervalxt/fmt.hpp"
 #include "../intervalxt/induction_step.hpp"
 #include "../intervalxt/interval_exchange_transformation.hpp"
 #include "../intervalxt/label.hpp"
@@ -354,14 +354,9 @@ std::string Implementation<IntervalExchangeTransformation>::render(const Interva
 }
 
 std::ostream& operator<<(std::ostream& os, const IntervalExchangeTransformation& self) {
-  return os << boost::algorithm::join(self.impl->top | rx::transform([&](const auto& interval) {
-                                        return "[" + self.impl->lengths->render(interval) + ": " + boost::lexical_cast<std::string>(self.impl->lengths->get(interval)) + "]";
-                                      }) | rx::to_vector(),
-                                      " ")
-            << " / " << boost::algorithm::join(self.impl->bottom | rx::transform([&](const auto& interval) {
-                                                 return "[" + self.impl->lengths->render(interval) + "]";
-                                               }) | rx::to_vector(),
-                                               " ");
+  return os << fmt::format("{} / {}",
+                           fmt::join(self.impl->top | rx::transform([&](const auto& interval) { return fmt::format("[{}: {}]", self.impl->lengths->render(interval), self.impl->lengths->get(interval)); }) | rx::to_vector(), " "),
+                           fmt::join(self.impl->bottom | rx::transform([&](const auto& interval) { return fmt::format("[{}]", self.impl->lengths->render(interval)); }) | rx::to_vector(), " "));
 }
 
 }  // namespace intervalxt

--- a/libintervalxt/src/separatrix.cc
+++ b/libintervalxt/src/separatrix.cc
@@ -84,7 +84,7 @@ Separatrix Implementation<Separatrix>::atBottom(std::shared_ptr<DecompositionSta
 }
 
 ostream& operator<<(ostream& os, const Separatrix& self) {
-  return os << Implementation<DynamicalDecomposition>::render(self.impl->decomposition, self.impl->label) << (self.impl->orientation == Orientation::PARALLEL ? "+" : "-");
+  return os << self.impl->decomposition->render(self.impl->label) << (self.impl->orientation == Orientation::PARALLEL ? "+" : "-");
 }
 
 }  // namespace intervalxt

--- a/libintervalxt/test/dynamical_decomposition.test.cc
+++ b/libintervalxt/test/dynamical_decomposition.test.cc
@@ -19,6 +19,7 @@
  *********************************************************************/
 
 #include <e-antic/renfxx.h>
+#include <fmt/format.h>
 #include <boost/logic/tribool.hpp>
 
 #include "external/catch2/single_include/catch2/catch.hpp"
@@ -26,14 +27,13 @@
 #include "../intervalxt/connection.hpp"
 #include "../intervalxt/decomposition_step.hpp"
 #include "../intervalxt/dynamical_decomposition.hpp"
+#include "../intervalxt/fmt.hpp"
 #include "../intervalxt/interval_exchange_transformation.hpp"
 #include "../intervalxt/sample/e-antic-arithmetic.hpp"
 #include "../intervalxt/sample/lengths.hpp"
 
-using boost::lexical_cast;
 using eantic::renf_class;
 using eantic::renf_elem_class;
-using std::string;
 using Result = ::intervalxt::DecompositionStep::Result;
 
 namespace intervalxt::test {
@@ -55,7 +55,7 @@ TEST_CASE("Decomposition of an IET") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(component) == "[d] [c] [a] [e] [b] -[e] -[d] -[c] -[a] -[b]");
+    REQUIRE(fmt::format("{}", component) == "[d] [c] [a] [e] [b] -[e] -[d] -[c] -[a] -[b]");
 
     auto step0 = component.decompositionStep();
     CAPTURE(step0);
@@ -63,18 +63,18 @@ TEST_CASE("Decomposition of an IET") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(*step0.connection) == "[d+ ⚯ b-]");
-    REQUIRE(lexical_cast<string>(component) == "[c] [a] [e] [d] [d+ ⚯ b-] -[e] -[d] -[c] -[a] [b- ⚯ d+]");
+    REQUIRE(fmt::format("{}", *step0.connection) == "[d+ ⚯ b-]");
+    REQUIRE(fmt::format("{}", component) == "[c] [a] [e] [d] [d+ ⚯ b-] -[e] -[d] -[c] -[a] [b- ⚯ d+]");
 
     auto step1 = component.decompositionStep();
     CAPTURE(step1);
     REQUIRE(step1.result == Result::SEPARATING_CONNECTION);
-    REQUIRE(lexical_cast<string>(*step1.connection) == "[a+ ⚯ c-]");
-    REQUIRE(lexical_cast<string>(component) == "[c] [a] [a+ ⚯ c-] -[c] -[a] [b- ⚯ d+]");
+    REQUIRE(fmt::format("{}", *step1.connection) == "[a+ ⚯ c-]");
+    REQUIRE(fmt::format("{}", component) == "[c] [a] [a+ ⚯ c-] -[c] -[a] [b- ⚯ d+]");
 
     {
       auto cylinder = *step1.additionalComponent;
-      REQUIRE(lexical_cast<std::string>(cylinder) == "[e] [d] [d+ ⚯ b-] -[e] -[d] [c- ⚯ a+]");
+      REQUIRE(fmt::format("{}", cylinder) == "[e] [d] [d+ ⚯ b-] -[e] -[d] [c- ⚯ a+]");
       REQUIRE(indeterminate(cylinder.cylinder()));
       REQUIRE(indeterminate(cylinder.withoutPeriodicTrajectory()));
       REQUIRE(indeterminate(cylinder.keane()));
@@ -93,7 +93,7 @@ TEST_CASE("Decomposition of an IET") {
       REQUIRE(not cylinder.withoutPeriodicTrajectory());
       REQUIRE(not cylinder.keane());
 
-      REQUIRE(lexical_cast<string>(cylinder) == "[e] [e+ ⚯ d-] [d+ ⚯ b-] -[e] [d- ⚯ e+] [c- ⚯ a+]");
+      REQUIRE(fmt::format("{}", cylinder) == "[e] [e+ ⚯ d-] [d+ ⚯ b-] -[e] [d- ⚯ e+] [c- ⚯ a+]");
     }
 
     {
@@ -102,7 +102,7 @@ TEST_CASE("Decomposition of an IET") {
       REQUIRE(not component.cylinder());
       REQUIRE(component.withoutPeriodicTrajectory());
 
-      REQUIRE(lexical_cast<string>(component) == "[c] [a] [a+ ⚯ c-] -[c] -[a] [b- ⚯ d+]");
+      REQUIRE(fmt::format("{}", component) == "[c] [a] [a+ ⚯ c-] -[c] -[a] [b- ⚯ d+]");
     }
   }
 
@@ -116,7 +116,7 @@ TEST_CASE("Decomposition of an IET") {
       CAPTURE(keane);
       REQUIRE(keane.withoutPeriodicTrajectory());
 
-      REQUIRE(lexical_cast<string>(keane) == "[c] [a] [a+ ⚯ c-] -[c] -[a] [b- ⚯ d+]");
+      REQUIRE(fmt::format("{}", keane) == "[c] [a] [a+ ⚯ c-] -[c] -[a] [b- ⚯ d+]");
     }
 
     {
@@ -124,7 +124,7 @@ TEST_CASE("Decomposition of an IET") {
       CAPTURE(cylinder);
       REQUIRE(cylinder.cylinder());
 
-      REQUIRE(lexical_cast<string>(cylinder) == "[e] [e+ ⚯ d-] [d+ ⚯ b-] -[e] [d- ⚯ e+] [c- ⚯ a+]");
+      REQUIRE(fmt::format("{}", cylinder) == "[e] [e+ ⚯ d-] [d+ ⚯ b-] -[e] [d- ⚯ e+] [c- ⚯ a+]");
     }
   }
 }
@@ -141,7 +141,7 @@ TEST_CASE("Decomposition of a Trivial IET") {
 
   auto cylinder = decomposition.components()[0];
 
-  REQUIRE(lexical_cast<string>(cylinder) == "[a] -[a]");
+  REQUIRE(fmt::format("{}", cylinder) == "[a] -[a]");
 }
 
 TEST_CASE("Decomposition of obvious Cylinders") {
@@ -159,7 +159,7 @@ TEST_CASE("Decomposition of obvious Cylinders") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(component) == "[b] [a] -[b] -[a]");
+    REQUIRE(fmt::format("{}", component) == "[b] [a] -[b] -[a]");
 
     auto step0 = component.decompositionStep();
     CAPTURE(step0);
@@ -167,12 +167,12 @@ TEST_CASE("Decomposition of obvious Cylinders") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(component) == "[b] [b+ ⚯ a-] -[b] [a- ⚯ b+]");
+    REQUIRE(fmt::format("{}", component) == "[b] [b+ ⚯ a-] -[b] [a- ⚯ b+]");
 
     auto step1 = component.decompositionStep();
     CAPTURE(step1);
     REQUIRE(step1.result == Result::CYLINDER);
-    REQUIRE(lexical_cast<string>(component) == "[b] [b+ ⚯ a-] -[b] [a- ⚯ b+]");
+    REQUIRE(fmt::format("{}", component) == "[b] [b+ ⚯ a-] -[b] [a- ⚯ b+]");
   }
 
   SECTION("Automatic Decomposition") {
@@ -182,7 +182,7 @@ TEST_CASE("Decomposition of obvious Cylinders") {
 
     auto component = decomposition.components()[0];
 
-    REQUIRE(lexical_cast<string>(component) == "[b] [b+ ⚯ a-] -[b] [a- ⚯ b+]");
+    REQUIRE(fmt::format("{}", component) == "[b] [b+ ⚯ a-] -[b] [a- ⚯ b+]");
   }
 }
 
@@ -201,7 +201,7 @@ TEST_CASE("Decomposition of Nested Cylinders") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(component) == "[c] [b] [a] -[c] -[b] -[a]");
+    REQUIRE(fmt::format("{}", component) == "[c] [b] [a] -[c] -[b] -[a]");
 
     auto step0 = component.decompositionStep();
     CAPTURE(step0);
@@ -209,7 +209,7 @@ TEST_CASE("Decomposition of Nested Cylinders") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(component) == "[b] [c] [c+ ⚯ a-] -[c] -[b] [a- ⚯ c+]");
+    REQUIRE(fmt::format("{}", component) == "[b] [c] [c+ ⚯ a-] -[c] -[b] [a- ⚯ c+]");
 
     auto step1 = component.decompositionStep();
     CAPTURE(step1);
@@ -221,7 +221,7 @@ TEST_CASE("Decomposition of Nested Cylinders") {
       CAPTURE(step2);
       REQUIRE(step2.result == Result::CYLINDER);
       REQUIRE(cylinder.cylinder());
-      REQUIRE(lexical_cast<string>(cylinder) == "[c] [c+ ⚯ a-] -[c] [b- ⚯ b+]");
+      REQUIRE(fmt::format("{}", cylinder) == "[c] [c+ ⚯ a-] -[c] [b- ⚯ b+]");
     }
 
     {
@@ -231,15 +231,15 @@ TEST_CASE("Decomposition of Nested Cylinders") {
       REQUIRE(step2.result == Result::CYLINDER);
 
       REQUIRE(component.cylinder());
-      REQUIRE(lexical_cast<string>(component) == "[b] [b+ ⚯ b-] -[b] [a- ⚯ c+]");
+      REQUIRE(fmt::format("{}", component) == "[b] [b+ ⚯ b-] -[b] [a- ⚯ c+]");
     }
   }
 
   SECTION("Automatic Decomposition") {
     REQUIRE(decomposition.decompose());
 
-    REQUIRE(lexical_cast<string>(decomposition.components()[0]) == "[b] [b+ ⚯ b-] -[b] [a- ⚯ c+]");
-    REQUIRE(lexical_cast<string>(decomposition.components()[1]) == "[c] [c+ ⚯ a-] -[c] [b- ⚯ b+]");
+    REQUIRE(fmt::format("{}", decomposition.components()[0]) == "[b] [b+ ⚯ b-] -[b] [a- ⚯ c+]");
+    REQUIRE(fmt::format("{}", decomposition.components()[1]) == "[c] [c+ ⚯ a-] -[c] [b- ⚯ b+]");
   }
 }
 
@@ -258,7 +258,7 @@ TEST_CASE("Decomposition of More Deeply Nested Cylinders") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(component) == "[d] [a] [c] [b] -[d] -[c] -[b] -[a]");
+    REQUIRE(fmt::format("{}", component) == "[d] [a] [c] [b] -[d] -[c] -[b] -[a]");
 
     auto step0 = component.decompositionStep();
     CAPTURE(step0);
@@ -266,7 +266,7 @@ TEST_CASE("Decomposition of More Deeply Nested Cylinders") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(component) == "[d] [d+ ⚯ a-] [c] [b] -[d] -[c] -[b] [a- ⚯ d+]");
+    REQUIRE(fmt::format("{}", component) == "[d] [d+ ⚯ a-] [c] [b] -[d] -[c] -[b] [a- ⚯ d+]");
 
     auto step1 = component.decompositionStep();
     CAPTURE(step1);
@@ -274,7 +274,7 @@ TEST_CASE("Decomposition of More Deeply Nested Cylinders") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(component) == "[c] [a- ⚯ d+] [d] [d+ ⚯ a-] [a+ ⚯ b-] -[d] -[c] [b- ⚯ a+]");
+    REQUIRE(fmt::format("{}", component) == "[c] [a- ⚯ d+] [d] [d+ ⚯ a-] [a+ ⚯ b-] -[d] -[c] [b- ⚯ a+]");
 
     auto step2 = component.decompositionStep();
     CAPTURE(step2);
@@ -282,14 +282,14 @@ TEST_CASE("Decomposition of More Deeply Nested Cylinders") {
     REQUIRE(indeterminate(component.cylinder()));
     REQUIRE(indeterminate(component.withoutPeriodicTrajectory()));
     REQUIRE(indeterminate(component.keane()));
-    REQUIRE(lexical_cast<string>(component) == "[c] [c+ ⚯ c-] -[c] [b- ⚯ a+]");
+    REQUIRE(fmt::format("{}", component) == "[c] [c+ ⚯ c-] -[c] [b- ⚯ a+]");
   }
 
   SECTION("Automatic Decomposition") {
     REQUIRE(decomposition.decompose());
 
-    REQUIRE(lexical_cast<string>(decomposition.components()[0]) == "[c] [c+ ⚯ c-] -[c] [b- ⚯ a+]");
-    REQUIRE(lexical_cast<string>(decomposition.components()[1]) == "[d] [d+ ⚯ a-] [a+ ⚯ b-] -[d] [c- ⚯ c+] [a- ⚯ d+]");
+    REQUIRE(fmt::format("{}", decomposition.components()[0]) == "[c] [c+ ⚯ c-] -[c] [b- ⚯ a+]");
+    REQUIRE(fmt::format("{}", decomposition.components()[1]) == "[d] [d+ ⚯ a-] [a+ ⚯ b-] -[d] [c- ⚯ c+] [a- ⚯ d+]");
   }
 }
 
@@ -309,11 +309,11 @@ TEST_CASE("Decomposition With Injected Connections") {
   component.inject(-HalfEdge(component, b), {}, {{b, e}, {e, f}});
   component.inject(-HalfEdge(component, a), {}, {{a, c}});
 
-  REQUIRE(lexical_cast<string>(component) == "[b] [b+ ⚯ e-] [e+ ⚯ f-] [a] [a+ ⚯ c-] -[b] [e- ⚯ b+] [d+ ⚯ a-] -[a] [c- ⚯ a+] [f- ⚯ e+] [a- ⚯ d+]");
+  REQUIRE(fmt::format("{}", component) == "[b] [b+ ⚯ e-] [e+ ⚯ f-] [a] [a+ ⚯ c-] -[b] [e- ⚯ b+] [d+ ⚯ a-] -[a] [c- ⚯ a+] [f- ⚯ e+] [a- ⚯ d+]");
 
   component.decompose();
 
-  REQUIRE(lexical_cast<string>(component) == "[b] [b+ ⚯ e-] [e+ ⚯ f-] [f+ ⚯ d-] [d+ ⚯ a-] [a+ ⚯ c-] -[b] [e- ⚯ b+] [d- ⚯ f+] [c- ⚯ a+] [f- ⚯ e+] [a- ⚯ d+]");
+  REQUIRE(fmt::format("{}", component) == "[b] [b+ ⚯ e-] [e+ ⚯ f-] [f+ ⚯ d-] [d+ ⚯ a-] [a+ ⚯ c-] -[b] [e- ⚯ b+] [d- ⚯ f+] [c- ⚯ a+] [f- ⚯ e+] [a- ⚯ d+]");
 }
 
 TEST_CASE("Decomposition Coming From a Case on the 1221 Surface") {
@@ -332,7 +332,7 @@ TEST_CASE("Decomposition Coming From a Case on the 1221 Surface") {
 
   component.decompose();
 
-  REQUIRE(lexical_cast<string>(component) == "[d] [d+ ⚯ b-] [b+ ⚯ a-] [a+ ⚯ c-] -[d] [b- ⚯ d+] [a- ⚯ b+] [c- ⚯ a+]");
+  REQUIRE(fmt::format("{}", component) == "[d] [d+ ⚯ b-] [b+ ⚯ a-] [a+ ⚯ c-] -[d] [b- ⚯ d+] [a- ⚯ b+] [c- ⚯ a+]");
 }
 
 }  // namespace intervalxt::test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     # compile-time dependencies of libintervalxt
     - boost-cpp
     - e-antic 1.*
+    - fmt
     - gmp
     - ppl
 {%- endif %}


### PR DESCRIPTION
This is much more convenient to use than the boost things (lexical_cast
and join). Also, this will be part of the C++20 standard so we likely
can drop {fmt} at some point and just use standard C++ again.

Also, I hope that I can use this to drop some of the ostream<< hacks
that I need for cppyy to work. If not, I probably have to add
intervalxt::to_string() overloads as well.