### PR TITLE
Drop videlec from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @saraedum @videlec
+* @saraedum

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,4 +94,3 @@ about:
 extra:
   recipe-maintainers:
     - saraedum
-    - videlec


### PR DESCRIPTION
so he does not get review requests from GitHub whenever I open a PR.