### PR TITLE
Bring back rudimentary cereal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ run
 ```
 conda config --add channels conda-forge
 conda config --add channels flatsurf # if you want to pull in the latest version of dependencies
-conda create -n intervalxt-build cxx-compiler libtool automake boost-cpp e-antic benchmark ccache ppl libexactreal pytest cppyy fmt
+conda create -n intervalxt-build cxx-compiler libtool automake boost-cpp e-antic benchmark ccache ppl libexactreal pytest cppyy fmt cppyythonizations
 conda activate intervalxt-build
 export CPPFLAGS="-isystem $CONDA_PREFIX/include"
 export CFLAGS="$CPPFLAGS"

--- a/libintervalxt/.gitignore
+++ b/libintervalxt/.gitignore
@@ -29,3 +29,4 @@ m4/ltoptions.m4
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
+

--- a/libintervalxt/intervalxt/cereal.hpp
+++ b/libintervalxt/intervalxt/cereal.hpp
@@ -23,12 +23,12 @@
 
 #include <map>
 
+#include <fmt/format.h>
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/seq/push_back.hpp>
 #include <cereal/cereal.hpp>
 #include <cereal/types/memory.hpp>
 #include <cereal/types/polymorphic.hpp>
-#include <fmt/format.h>
 
 #include "interval_exchange_transformation.hpp"
 #include "label.hpp"
@@ -164,7 +164,7 @@ void serialize(Archive& archive, Lengths& self) {
 // LIBINTERVALXT_LENGTHS_REGISTER_SERIALIZATION("ThisStringWillShowUpInSerializationOutput", (MyLengths));
 // ```
 
-      /*
+/*
 template <typename Archive>
 void save(Archive& archive, const Lengths& self) {
   BOOST_PP_SEQ_FOR_EACH(LIBINTERVALXT_TRY_SAVE, _, LIBINTERVALXT_LENGTHS_REGISTERED_SERIALIZATION);

--- a/libintervalxt/intervalxt/cereal.hpp
+++ b/libintervalxt/intervalxt/cereal.hpp
@@ -1,0 +1,220 @@
+/* ********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2019 Vincent Delecroix
+ *        Copyright (C) 2019 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ * *******************************************************************/
+
+#ifndef LIBINTERVALXT_CEREAL_HPP
+#define LIBINTERVALXT_CEREAL_HPP
+
+#include <map>
+
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/seq/push_back.hpp>
+#include <cereal/cereal.hpp>
+#include <cereal/types/memory.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <fmt/format.h>
+
+#include "interval_exchange_transformation.hpp"
+#include "label.hpp"
+#include "length.hpp"
+
+namespace intervalxt {
+
+template <typename T>
+struct Serialization {
+  template <typename Archive>
+  auto save(Archive&, const T&) {
+    static_assert(!std::is_same_v<T, T>, "no Serialization specialization for this type defined");
+  }
+
+  template <typename Archive>
+  void load(Archive&, T&) {
+    static_assert(!std::is_same_v<T, T>, "no Serialization specialization for this type defined");
+  }
+};
+
+template <>
+struct Serialization<Label> {
+  template <typename Archive>
+  size_t save(Archive&, const Label& self) {
+    return self.id;
+  }
+
+  template <typename Archive>
+  void load(const Archive&, Label& self, const size_t& id) {
+    self.id = id;
+  }
+};
+
+template <>
+struct Serialization<IntervalExchangeTransformation> {
+  template <typename Archive>
+  void save(Archive& archive, const IntervalExchangeTransformation& self) {
+    archive(cereal::make_nvp("top", self.top()));
+    archive(cereal::make_nvp("bottom", self.bottom()));
+    archive(cereal::make_nvp("lengths", self.lengths()));
+  }
+
+  template <typename Archive>
+  void load(Archive& archive, IntervalExchangeTransformation& self) {
+    std::vector<Label> top, bottom;
+    std::shared_ptr<Lengths> lengths;
+
+    archive(cereal::make_nvp("top", top));
+    archive(cereal::make_nvp("bottom", bottom));
+    archive(cereal::make_nvp("lengths", lengths));
+
+    if (lengths == nullptr) {
+      assert(top.empty() && bottom.empty() && "There must not be top & bottom labels when there are no lengths to give meaning to them.");
+      // The default initialized self is already the correct deserialization.
+      return;
+    }
+
+    self = IntervalExchangeTransformation(lengths, top, bottom);
+  }
+};
+
+/*
+template <>
+struct Serialization<Lengths> {
+  struct ErasedSerializationHelperBase {
+    virtual ~ErasedSerializationHelperBase(){} 
+
+    virtual Lengths lengths() = 0;
+
+    template <typename Archive>
+    void serialize(Archive& archive) {}
+  };
+
+  template <typename T>
+  struct ErasedSerializationHelper : public ErasedSerializationHelperBase {
+    template <typename Archive>
+    void serialize(Archive& archive) { archive(*t); }
+
+    Lengths lengths() override { return *t; }
+
+    T* t = new T();
+  };
+
+};
+
+// Note: For some strange reason, we cannot use a load/save pair here. Doing
+// so makes cereal complain that Label (!) has more than one save() function.
+template <typename Archive>
+void serialize(Archive& archive, Lengths& self) {
+  if constexpr (Archive::is_loading::value) {
+    static_assert(!Archive::is_saving::value, "serialize() must be either loading or saving but this archive is doing both");
+
+    std::unique_ptr<Serialization<Lengths>::ErasedSerializationHelperBase> serializable;
+
+    archive(serializable);
+
+    self = serializable->lengths();
+
+    // throw std::logic_error(fmt::format("not implemented for {}", typeid_of(self).name()));
+  } else {
+    static_assert(Archive::is_saving::value, "serialize() must be either loading or saving but this archive is not doing either");
+
+    std::unique_ptr<Serialization<Lengths>::ErasedSerializationHelperBase> serializable(static_cast<Serialization<Lengths>::ErasedSerializationHelperBase*>(self.serializable()));
+
+    archive(serializable);
+  }
+}
+
+#define LIBINTERVALXT_REGISTER_SERIALIZABLE_LENGTHS(TYPE) \
+  CEREAL_REGISTER_TYPE(::intervalxt::Serialization<::intervalxt::Lengths>::ErasedSerializationHelper<TYPE>); \
+  CEREAL_REGISTER_POLYMORPHIC_RELATION(::intervalxt::Serialization<::intervalxt::Lengths>::ErasedSerializationHelperBase, ::intervalxt::Serialization<::intervalxt::Lengths>::ErasedSerializationHelper<TYPE>);
+*/
+
+// Since Lengths is type-erased, its serialization works differently. If you
+// don't want to support serialization of your Lengths, then there is nothing
+// to do. Otherwise, implement any cereal serialization scheme, e.g., by
+// defining a serialize method in your Lengths class:
+// ```
+// template <typename Archive>
+// void serialize(Archive&);
+// ```
+// Additionally, you must register your lengths **before** including this file.
+// It is probably a good pattern to put this registration together with the
+// implementation of serialize into a cereal.hpp file that users that want to
+// use cereal serialization can optionally include:
+// ```
+// #include <cereal/cereal.hpp>
+// #include <intervalxt/lengths.hpp>
+//
+// template <typename Archive>
+// void MyLengths::serialize(Archive& archive) { ... }
+//
+// LIBINTERVALXT_LENGTHS_REGISTER_SERIALIZATION("ThisStringWillShowUpInSerializationOutput", (MyLengths));
+// ```
+
+      /*
+template <typename Archive>
+void save(Archive& archive, const Lengths& self) {
+  BOOST_PP_SEQ_FOR_EACH(LIBINTERVALXT_TRY_SAVE, _, LIBINTERVALXT_LENGTHS_REGISTERED_SERIALIZATION);
+  throw std::logic_error("not implemented: this Lengths do not support serialization; did you forget to call LIBINTERVALXT_LENGTHS_REGISTER_SERIALIZATION?");
+}
+*/
+
+/*
+template <typename Archive, typename T>
+void save(Archive& archive, const Length<T>& self) {
+  archive(cereal::make_nvp("value", self.value));
+}
+
+template <typename Archive, typename T>
+void load(Archive& archive, Length<T>& self) {
+  T value;
+  archive(value);
+  self = value;
+}
+
+template <typename Archive, typename Length>
+void save(Archive& archive, const Label<Length>& self) {
+  auto uuid = boost::lexical_cast<std::string>(static_cast<boost::uuids::uuid>(*self.impl->id));
+  archive(cereal::make_nvp("uuid", uuid));
+  archive(cereal::make_nvp("length", self.impl->length));
+}
+
+template <typename Archive, typename Length>
+void load(Archive& archive, Label<Length>& self) {
+  std::string uuid;
+  archive(cereal::make_nvp("uuid", uuid));
+  self.impl->id = detail::Id::make(boost::lexical_cast<boost::uuids::uuid>(uuid));
+  archive(cereal::make_nvp("length", self.impl->length));
+}
+
+template <typename Archive, typename Length>
+void save(Archive& archive, const IntervalExchangeTransformation<Length>& self) {
+  archive(cereal::make_nvp("top", self.top()));
+  archive(cereal::make_nvp("bottom", self.bottom()));
+}
+
+template <typename Archive, typename Length>
+void load(Archive& archive, IntervalExchangeTransformation<Length>& self) {
+  std::vector<Label<Length>> top, bottom;
+  archive(cereal::make_nvp("top", top));
+  archive(cereal::make_nvp("bottom", bottom));
+  self = IntervalExchangeTransformation<Length>(top, bottom);
+}
+*/
+
+}  // namespace intervalxt
+
+#endif

--- a/libintervalxt/intervalxt/cereal.hpp
+++ b/libintervalxt/intervalxt/cereal.hpp
@@ -26,6 +26,7 @@
 #include <fmt/format.h>
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/seq/push_back.hpp>
+
 #include <cereal/cereal.hpp>
 #include <cereal/types/memory.hpp>
 #include <cereal/types/polymorphic.hpp>

--- a/libintervalxt/intervalxt/cereal.hpp
+++ b/libintervalxt/intervalxt/cereal.hpp
@@ -30,6 +30,8 @@
 #include <cereal/types/memory.hpp>
 #include <cereal/types/polymorphic.hpp>
 
+#include "erased/cereal.hpp"
+
 #include "interval_exchange_transformation.hpp"
 #include "label.hpp"
 #include "length.hpp"
@@ -89,131 +91,6 @@ struct Serialization<IntervalExchangeTransformation> {
     self = IntervalExchangeTransformation(lengths, top, bottom);
   }
 };
-
-/*
-template <>
-struct Serialization<Lengths> {
-  struct ErasedSerializationHelperBase {
-    virtual ~ErasedSerializationHelperBase(){} 
-
-    virtual Lengths lengths() = 0;
-
-    template <typename Archive>
-    void serialize(Archive& archive) {}
-  };
-
-  template <typename T>
-  struct ErasedSerializationHelper : public ErasedSerializationHelperBase {
-    template <typename Archive>
-    void serialize(Archive& archive) { archive(*t); }
-
-    Lengths lengths() override { return *t; }
-
-    T* t = new T();
-  };
-
-};
-
-// Note: For some strange reason, we cannot use a load/save pair here. Doing
-// so makes cereal complain that Label (!) has more than one save() function.
-template <typename Archive>
-void serialize(Archive& archive, Lengths& self) {
-  if constexpr (Archive::is_loading::value) {
-    static_assert(!Archive::is_saving::value, "serialize() must be either loading or saving but this archive is doing both");
-
-    std::unique_ptr<Serialization<Lengths>::ErasedSerializationHelperBase> serializable;
-
-    archive(serializable);
-
-    self = serializable->lengths();
-
-    // throw std::logic_error(fmt::format("not implemented for {}", typeid_of(self).name()));
-  } else {
-    static_assert(Archive::is_saving::value, "serialize() must be either loading or saving but this archive is not doing either");
-
-    std::unique_ptr<Serialization<Lengths>::ErasedSerializationHelperBase> serializable(static_cast<Serialization<Lengths>::ErasedSerializationHelperBase*>(self.serializable()));
-
-    archive(serializable);
-  }
-}
-
-#define LIBINTERVALXT_REGISTER_SERIALIZABLE_LENGTHS(TYPE) \
-  CEREAL_REGISTER_TYPE(::intervalxt::Serialization<::intervalxt::Lengths>::ErasedSerializationHelper<TYPE>); \
-  CEREAL_REGISTER_POLYMORPHIC_RELATION(::intervalxt::Serialization<::intervalxt::Lengths>::ErasedSerializationHelperBase, ::intervalxt::Serialization<::intervalxt::Lengths>::ErasedSerializationHelper<TYPE>);
-*/
-
-// Since Lengths is type-erased, its serialization works differently. If you
-// don't want to support serialization of your Lengths, then there is nothing
-// to do. Otherwise, implement any cereal serialization scheme, e.g., by
-// defining a serialize method in your Lengths class:
-// ```
-// template <typename Archive>
-// void serialize(Archive&);
-// ```
-// Additionally, you must register your lengths **before** including this file.
-// It is probably a good pattern to put this registration together with the
-// implementation of serialize into a cereal.hpp file that users that want to
-// use cereal serialization can optionally include:
-// ```
-// #include <cereal/cereal.hpp>
-// #include <intervalxt/lengths.hpp>
-//
-// template <typename Archive>
-// void MyLengths::serialize(Archive& archive) { ... }
-//
-// LIBINTERVALXT_LENGTHS_REGISTER_SERIALIZATION("ThisStringWillShowUpInSerializationOutput", (MyLengths));
-// ```
-
-/*
-template <typename Archive>
-void save(Archive& archive, const Lengths& self) {
-  BOOST_PP_SEQ_FOR_EACH(LIBINTERVALXT_TRY_SAVE, _, LIBINTERVALXT_LENGTHS_REGISTERED_SERIALIZATION);
-  throw std::logic_error("not implemented: this Lengths do not support serialization; did you forget to call LIBINTERVALXT_LENGTHS_REGISTER_SERIALIZATION?");
-}
-*/
-
-/*
-template <typename Archive, typename T>
-void save(Archive& archive, const Length<T>& self) {
-  archive(cereal::make_nvp("value", self.value));
-}
-
-template <typename Archive, typename T>
-void load(Archive& archive, Length<T>& self) {
-  T value;
-  archive(value);
-  self = value;
-}
-
-template <typename Archive, typename Length>
-void save(Archive& archive, const Label<Length>& self) {
-  auto uuid = boost::lexical_cast<std::string>(static_cast<boost::uuids::uuid>(*self.impl->id));
-  archive(cereal::make_nvp("uuid", uuid));
-  archive(cereal::make_nvp("length", self.impl->length));
-}
-
-template <typename Archive, typename Length>
-void load(Archive& archive, Label<Length>& self) {
-  std::string uuid;
-  archive(cereal::make_nvp("uuid", uuid));
-  self.impl->id = detail::Id::make(boost::lexical_cast<boost::uuids::uuid>(uuid));
-  archive(cereal::make_nvp("length", self.impl->length));
-}
-
-template <typename Archive, typename Length>
-void save(Archive& archive, const IntervalExchangeTransformation<Length>& self) {
-  archive(cereal::make_nvp("top", self.top()));
-  archive(cereal::make_nvp("bottom", self.bottom()));
-}
-
-template <typename Archive, typename Length>
-void load(Archive& archive, IntervalExchangeTransformation<Length>& self) {
-  std::vector<Label<Length>> top, bottom;
-  archive(cereal::make_nvp("top", top));
-  archive(cereal::make_nvp("bottom", bottom));
-  self = IntervalExchangeTransformation<Length>(top, bottom);
-}
-*/
 
 }  // namespace intervalxt
 

--- a/libintervalxt/intervalxt/cppyy.hpp
+++ b/libintervalxt/intervalxt/cppyy.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <vector>
 
+#include "cereal.hpp"
 #include "forward.hpp"
 #include "interval_exchange_transformation.hpp"
 #include "label.hpp"

--- a/libintervalxt/intervalxt/erased/README.md
+++ b/libintervalxt/intervalxt/erased/README.md
@@ -1,0 +1,103 @@
+Cereal Serialization Support for Type Erased Types
+==================================================
+
+The steps below let you use type erasure with [cereal](http://uscilab.github.io/cereal/quickstart.html) to serialize types
+such as [`boost::type_erasure::any`](https://www.boost.org/doc/libs/1_72_0/doc/html/boost_typeerasure.html).
+
+Note that there are some assumptions for this to work:
+
+* You need to be able to adapt the type erasure definition [^1]
+* The any you want to serialize capture by value and [not by reference](https://www.boost.org/doc/libs/1_70_0/doc/html/boost_typeerasure/any.html#boost_typeerasure.any.references) [^2]
+* The serializable unerased types must be default constructible and copy-assignable [^3]
+
+Make a Boost Type Erasure Type Serializable
+-------------------------------------------
+
+For these notes, we'll assume that your type's definition is
+
+```cpp
+using Interface = boost::mpl::vector<
+  …
+>;
+
+using ErasedType = boost::type_erasure::any<Interface>;
+```
+
+1. Add a free function to your type erasure declaration that converts to a serializable polymorphic type.
+
+```cpp
+#include <intervalxt/erased/boost.hpp>
+
+// Forward declare a traits class that connects an erased serializable type
+// with your ErasedType.
+struct ErasedTypeSerialization;
+
+using Interface = boost::mpl::vector<
+  …,
+  ::intervalxt::erased::is_serializable<ErasedTypeSerialization>
+>
+
+using ErasedType = …;
+
+// Implement the traits class from above.
+struct ErasedTypeSerialization {
+  using Erased = ErasedType;
+};
+```
+
+2. Implement a free function `serializable()`
+
+You might want to put this definition right below your `using ErasedType = …;`.
+
+```cpp
+#include <intervalxt/erased/serializable.hpp>
+
+template <typename T>
+::intervalxt::erased::Serializable<ErasedTypeSerialization>::SerializableWrap<T> serializable(const T& unerased) {
+  return ::intervalxt::erased::Serializable<ErasedTypeSerialization>::make(unerased);
+}
+```
+
+3. Make your unerased types serializable
+
+You might want to do this in a header that your users are not required to pull
+in, say `cereal.hpp`, so that they do not have to pull in the entire cereal
+stack unless they are actually using serialization.
+
+```cpp
+#include <cereal/types/polymorphic.hpp>
+#include <intervalxt/erased/cereal.hpp>
+
+// Implement serialization using any of the methods supported by cereal, e.g.,
+// with a free serialize() function.
+template <typename Archive>
+void serialize(Archive& archive, Unerased& unerased) {
+  …
+}
+
+// Register the Serializable<> types with cereal's polymorphism machinery for
+// each unerased type you want to deserialize.
+// IMPORTANT: Tell your users that they must include this header file *after*
+// any cereal/archives/ files.
+LIBINTERVALXT_ERASED_REGISTER((::full::namespace::ErasedTypeSerialization), (::full::namespace::Unerased));
+```
+
+That's it. Now your erased types should serialize and deserialize (they
+serialize as unique pointers to a helper class that contains your unerased
+type.)
+
+[^1]: Alternatively, we could have used `dynamic_any_cast` to cross cast the
+  erased type to a type that has the `serializable()` introduced in 1. The
+  downside of this approach is that all unerased types would have to state that
+  they satisfy this requirement explicitly by calling `register_binding`. Since
+  this is less intrusive, it would still have been the better choice. Pull
+  Requests are welcome.
+
+[^2]: It is a unclear to the authors what is supposed to happen if something is
+  captured by reference. Cereal does not support references so we do not
+  either.
+
+[^3]: Both of these do not seem to be hard requirements. Pull Requests to
+  remove these requirements are welcome. Cereal supports serialization of types
+  without a default constructor, and erased types can be [constructed inplace
+  in boost](https://www.boost.org/doc/libs/1_70_0/doc/html/boost_typeerasure/any.html#boost_typeerasure.any.construction).

--- a/libintervalxt/intervalxt/erased/boost.hpp
+++ b/libintervalxt/intervalxt/erased/boost.hpp
@@ -30,7 +30,7 @@
 
 namespace intervalxt::erased {
 
-BOOST_TYPE_ERASURE_FREE((has_free_serializable), serializable, 1) 
+BOOST_TYPE_ERASURE_FREE((has_free_serializable), serializable, 1)
 
 // Concept that asserts the existence of a free serializable(const Erased&)
 // function which returns a pointer to a polymorphic object that can be handled
@@ -38,6 +38,6 @@ BOOST_TYPE_ERASURE_FREE((has_free_serializable), serializable, 1)
 template <typename Serialization>
 using is_serializable = ::intervalxt::erased::has_free_serializable<std::unique_ptr<::intervalxt::erased::Serializable<Serialization>>(const boost::type_erasure::_self&)>;
 
-}
+}  // namespace intervalxt::erased
 
 #endif

--- a/libintervalxt/intervalxt/erased/boost.hpp
+++ b/libintervalxt/intervalxt/erased/boost.hpp
@@ -1,8 +1,8 @@
 /**********************************************************************
  *  This file is part of intervalxt.
  *
- *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,47 +18,26 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-// This file forward declares all the types in the intervalxt namespace.
+#ifndef LIBINTERVALXT_ERASED_BOOST_HPP
+#define LIBINTERVALXT_ERASED_BOOST_HPP
 
-#ifndef LIBINTERVALXT_FORWARD_HPP
-#define LIBINTERVALXT_FORWARD_HPP
+#include <memory>
 
-#include <optional>
-#include <variant>
+#include <boost/type_erasure/any.hpp>
+#include <boost/type_erasure/free.hpp>
 
-#include "intervalxt.hpp"
+#include "forward.hpp"
 
-namespace intervalxt {
+namespace intervalxt::erased {
 
-class Label;
+BOOST_TYPE_ERASURE_FREE((has_free_serializable), serializable, 1) 
 
-class IntervalExchangeTransformation;
+// Concept that asserts the existence of a free serializable(const Erased&)
+// function which returns a pointer to a polymorphic object that can be handled
+// by cereal.
+template <typename Serialization>
+using is_serializable = ::intervalxt::erased::has_free_serializable<std::unique_ptr<::intervalxt::erased::Serializable<Serialization>>(const boost::type_erasure::_self&)>;
 
-class DynamicalDecomposition;
-
-class Component;
-
-class HalfEdge;
-
-class Separatrix;
-
-struct DecompositionStep;
-
-struct InductionStep;
-
-class Connection;
-
-using Side = std::variant<Connection, HalfEdge>;
-
-template <typename T>
-class Serializable;
-
-template <typename T>
-struct Serialization;
-
-template <typename T>
-class Implementation;
-
-}  // namespace intervalxt
+}
 
 #endif

--- a/libintervalxt/intervalxt/erased/cereal.hpp
+++ b/libintervalxt/intervalxt/erased/cereal.hpp
@@ -23,8 +23,8 @@
 
 #include "serializable.hpp"
 
-#include "detail/unparen.hpp"
 #include "detail/cereal.hpp"
+#include "detail/unparen.hpp"
 
 namespace intervalxt::erased {
 
@@ -37,6 +37,6 @@ namespace intervalxt::erased {
 #define LIBINTERVALXT_ERASED_REGISTER(SERIALIZATION, UNERASED) \
   CEREAL_REGISTER_TYPE(::intervalxt::erased::detail::Serializable<typename ::intervalxt::erased::detail::unparen<void UNERASED>::type, ::intervalxt::erased::Serializable<typename ::intervalxt::erased::detail::unparen<void SERIALIZATION>::type>>)
 
-}
+}  // namespace intervalxt::erased
 
 #endif

--- a/libintervalxt/intervalxt/erased/cereal.hpp
+++ b/libintervalxt/intervalxt/erased/cereal.hpp
@@ -1,0 +1,42 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_ERASED_CEREAL_HPP
+#define LIBINTERVALXT_ERASED_CEREAL_HPP
+
+#include "serializable.hpp"
+
+#include "detail/unparen.hpp"
+#include "detail/cereal.hpp"
+
+namespace intervalxt::erased {
+
+// Register our derived Serializable type with cereal's polymorphism machinery.
+// For this to work, users need to have <cereal/types/polymorphic.hpp> included.
+// We do not include it here explicitly since we do not want to make
+// assumptions on how cereal was included.
+// Further note, that we cannot do CEREAL_REGISTER_POLYMORPHIC_RELATION() since
+// that cannot handle type names containing commas.
+#define LIBINTERVALXT_ERASED_REGISTER(SERIALIZATION, UNERASED) \
+  CEREAL_REGISTER_TYPE(::intervalxt::erased::detail::Serializable<typename ::intervalxt::erased::detail::unparen<void UNERASED>::type, ::intervalxt::erased::Serializable<typename ::intervalxt::erased::detail::unparen<void SERIALIZATION>::type>>)
+
+}
+
+#endif

--- a/libintervalxt/intervalxt/erased/detail/cereal.hpp
+++ b/libintervalxt/intervalxt/erased/detail/cereal.hpp
@@ -34,7 +34,7 @@ namespace cereal {
 template <typename Base>
 struct base_class;
 
-}
+}  // namespace cereal
 
 namespace intervalxt::erased::detail {
 
@@ -52,6 +52,6 @@ void Serializable<Unerased, Base>::load_(Archive& archive) {
   archive(unerased);
 }
 
-}
+}  // namespace intervalxt::erased::detail
 
 #endif

--- a/libintervalxt/intervalxt/erased/detail/cereal.hpp
+++ b/libintervalxt/intervalxt/erased/detail/cereal.hpp
@@ -1,0 +1,57 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_ERASED_DETAIL_CEREAL_HPP
+#define LIBINTERVALXT_ERASED_DETAIL_CEREAL_HPP
+
+#include <stdexcept>
+
+#include "serializable.hpp"
+
+namespace cereal {
+
+// Forward declare cereal's base_class struct so IDEs do not complain about
+// base_class usage below. We choose not to include
+// <cereal/types/base_class.hpp> here explicitly since we do not know how the
+// user brought the cereal headers on their search path.
+template <typename Base>
+struct base_class;
+
+}
+
+namespace intervalxt::erased::detail {
+
+template <typename Unerased, typename Base>
+template <typename Archive>
+void Serializable<Unerased, Base>::save_(Archive& archive) const {
+  archive(::cereal::base_class<Base>(this));
+  archive(unerased);
+}
+
+template <typename Unerased, typename Base>
+template <typename Archive>
+void Serializable<Unerased, Base>::load_(Archive& archive) {
+  archive(::cereal::base_class<Base>(this));
+  archive(unerased);
+}
+
+}
+
+#endif

--- a/libintervalxt/intervalxt/erased/detail/serializable.hpp
+++ b/libintervalxt/intervalxt/erased/detail/serializable.hpp
@@ -64,6 +64,6 @@ struct Serializable : public Base {
   void load_(Archive&);
 };
 
-}
+}  // namespace intervalxt::erased::detail
 
 #endif

--- a/libintervalxt/intervalxt/erased/detail/serializable.hpp
+++ b/libintervalxt/intervalxt/erased/detail/serializable.hpp
@@ -1,0 +1,69 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_ERASED_DETAIL_SERIALIZABLE_HPP
+#define LIBINTERVALXT_ERASED_DETAIL_SERIALIZABLE_HPP
+
+#include <type_traits>
+
+#include "../forward.hpp"
+
+namespace intervalxt::erased::detail {
+
+template <typename Unerased, typename Base>
+struct Serializable : public Base {
+  using Erased = typename Base::Erased;
+
+  static_assert(!std::is_same_v<Unerased, Erased>);
+
+  Serializable() : unerased() {}
+  explicit Serializable(const Unerased& unerased) : unerased(unerased) {}
+
+  Erased erased() const override { return unerased; }
+
+ private:
+  Unerased unerased;
+
+  // A free save() function to serialize this type.  Since templatized save()
+  // has been causing trouble, we use the Barton-Nackman trick to redirect to a
+  // private member implementation.
+  template <typename Archive>
+  friend void save(Archive& archive, const Serializable& self) { self.save_(archive); }
+  // A free save() function to serialize this type.  Since templatized save()
+  // has been causing trouble, we use the Barton-Nackman trick to redirect to a
+  // private member implementation.
+  template <typename Archive>
+  friend void load(Archive& archive, Serializable& self) { self.load_(archive); }
+
+  // Write unerased to an archive. The implementation lives in cereal.hpp so we
+  // do not need to pull in all the cereal machinery unless this is actually
+  // used.
+  template <typename Archive>
+  void save_(Archive&) const;
+  // Load unerased from an archive. The implementation lives in cereal.hpp so we
+  // do not need to pull in all the cereal machinery unless this is actually
+  // used.
+  template <typename Archive>
+  void load_(Archive&);
+};
+
+}
+
+#endif

--- a/libintervalxt/intervalxt/erased/detail/unparen.hpp
+++ b/libintervalxt/intervalxt/erased/detail/unparen.hpp
@@ -26,14 +26,14 @@
 
 namespace intervalxt::erased::detail {
 
-template<typename T>
+template <typename T>
 struct unparen;
 
-template<typename R, typename T>
+template <typename R, typename T>
 struct unparen<R(T)> {
   typedef T type;
 };
 
-}
+}  // namespace intervalxt::erased::detail
 
 #endif

--- a/libintervalxt/intervalxt/erased/detail/unparen.hpp
+++ b/libintervalxt/intervalxt/erased/detail/unparen.hpp
@@ -1,8 +1,8 @@
 /**********************************************************************
  *  This file is part of intervalxt.
  *
- *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,47 +18,22 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-// This file forward declares all the types in the intervalxt namespace.
+#ifndef LIBINTERVALXT_ERASED_DETAIL_UNPAREN_HPP
+#define LIBINTERVALXT_ERASED_DETAIL_UNPAREN_HPP
 
-#ifndef LIBINTERVALXT_FORWARD_HPP
-#define LIBINTERVALXT_FORWARD_HPP
+// Remove () from macro types, similar to
+// https://stackoverflow.com/a/4298441/812379
 
-#include <optional>
-#include <variant>
+namespace intervalxt::erased::detail {
 
-#include "intervalxt.hpp"
+template<typename T>
+struct unparen;
 
-namespace intervalxt {
+template<typename R, typename T>
+struct unparen<R(T)> {
+  typedef T type;
+};
 
-class Label;
-
-class IntervalExchangeTransformation;
-
-class DynamicalDecomposition;
-
-class Component;
-
-class HalfEdge;
-
-class Separatrix;
-
-struct DecompositionStep;
-
-struct InductionStep;
-
-class Connection;
-
-using Side = std::variant<Connection, HalfEdge>;
-
-template <typename T>
-class Serializable;
-
-template <typename T>
-struct Serialization;
-
-template <typename T>
-class Implementation;
-
-}  // namespace intervalxt
+}
 
 #endif

--- a/libintervalxt/intervalxt/erased/forward.hpp
+++ b/libintervalxt/intervalxt/erased/forward.hpp
@@ -1,8 +1,8 @@
 /**********************************************************************
  *  This file is part of intervalxt.
  *
- *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,47 +18,14 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-// This file forward declares all the types in the intervalxt namespace.
+#ifndef LIBINTERVALXT_ERASED_FORWARD_HPP
+#define LIBINTERVALXT_ERASED_FORWARD_HPP
 
-#ifndef LIBINTERVALXT_FORWARD_HPP
-#define LIBINTERVALXT_FORWARD_HPP
+namespace intervalxt::erased {
 
-#include <optional>
-#include <variant>
+template <typename Serialization>
+struct Serializable;
 
-#include "intervalxt.hpp"
-
-namespace intervalxt {
-
-class Label;
-
-class IntervalExchangeTransformation;
-
-class DynamicalDecomposition;
-
-class Component;
-
-class HalfEdge;
-
-class Separatrix;
-
-struct DecompositionStep;
-
-struct InductionStep;
-
-class Connection;
-
-using Side = std::variant<Connection, HalfEdge>;
-
-template <typename T>
-class Serializable;
-
-template <typename T>
-struct Serialization;
-
-template <typename T>
-class Implementation;
-
-}  // namespace intervalxt
+}
 
 #endif

--- a/libintervalxt/intervalxt/erased/serializable.hpp
+++ b/libintervalxt/intervalxt/erased/serializable.hpp
@@ -1,0 +1,81 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_ERASED_SERIALIZABLE_HPP
+#define LIBINTERVALXT_ERASED_SERIALIZABLE_HPP
+
+#include <memory>
+#include <type_traits>
+
+#include "detail/serializable.hpp"
+
+namespace intervalxt::erased {
+
+template <typename Serialization>
+struct Serializable {
+  using Erased = typename Serialization::Erased;
+
+  // A serializable wrapper type for Unerased.
+  template <typename Unerased>
+  using SerializableWrap = std::enable_if_t<
+    std::is_assignable_v<Erased, Unerased> && !std::is_same_v<Erased, std::decay_t<Unerased>>,
+    std::unique_ptr<Serializable>>;
+
+  virtual ~Serializable() {}
+
+  virtual Erased erased() const = 0;
+
+  // Turn unerased into a pointer to a polymorphic serializable wrapper type.
+  template <typename T>
+  static SerializableWrap<T> make(const T& unerased) {
+    return std::make_unique<detail::Serializable<T, Serializable>>(unerased);
+  }
+
+ private:
+  // Serialize the erased type through this polymorphic wrapper type.
+  template <typename Archive>
+  friend void save(Archive& archive, const Erased& self) {
+    archive(serializable(self));
+  }
+
+  // Deserialize the erased type through this polymorphic wrapper type.
+  template <typename Archive>
+  friend void load(Archive& archive, Erased& self) {
+    std::unique_ptr<Serializable> tmp;
+    archive(tmp);
+    self = tmp->erased();
+  }
+
+  template <typename Archive>
+  friend void save(Archive&, const Serializable&) {
+    // Intentionally empty. There is nothing to serialize for this virtual
+    // base type, the subtypes do the actual (de)serialization.
+  }
+
+  template <typename Archive>
+  friend void load(Archive&, Serializable&) {
+    // Intentionally empty. There is nothing to deserialize for this virtual
+    // base type, the subtypes do the actual (de)serialization.
+  }
+};
+
+}
+
+#endif

--- a/libintervalxt/intervalxt/erased/serializable.hpp
+++ b/libintervalxt/intervalxt/erased/serializable.hpp
@@ -35,8 +35,8 @@ struct Serializable {
   // A serializable wrapper type for Unerased.
   template <typename Unerased>
   using SerializableWrap = std::enable_if_t<
-    std::is_assignable_v<Erased, Unerased> && !std::is_same_v<Erased, std::decay_t<Unerased>>,
-    std::unique_ptr<Serializable>>;
+      std::is_assignable_v<Erased, Unerased> && !std::is_same_v<Erased, std::decay_t<Unerased>>,
+      std::unique_ptr<Serializable>>;
 
   virtual ~Serializable() {}
 
@@ -76,6 +76,6 @@ struct Serializable {
   }
 };
 
-}
+}  // namespace intervalxt::erased
 
 #endif

--- a/libintervalxt/intervalxt/interval_exchange_transformation.hpp
+++ b/libintervalxt/intervalxt/interval_exchange_transformation.hpp
@@ -32,12 +32,13 @@
 
 #include "external/spimpl/spimpl.h"
 
-#include "forward.hpp"
+#include "serializable.hpp"
 #include "lengths.hpp"
 
 namespace intervalxt {
 
-class IntervalExchangeTransformation : boost::equality_comparable<IntervalExchangeTransformation> {
+class IntervalExchangeTransformation : boost::equality_comparable<IntervalExchangeTransformation>,
+  Serializable<IntervalExchangeTransformation> {
  public:
   IntervalExchangeTransformation();
   IntervalExchangeTransformation(std::shared_ptr<Lengths>, const std::vector<Label> &top, const std::vector<Label> &bottom);
@@ -74,6 +75,9 @@ class IntervalExchangeTransformation : boost::equality_comparable<IntervalExchan
   std::vector<Label> top() const noexcept;
   // Return the labels of the bottom permutation (in order.)
   std::vector<Label> bottom() const noexcept;
+
+  // Return the lengths underlying the intervals of this interval exchange transformation.
+  std::shared_ptr<const Lengths> lengths() const;
 
   // Return the number of intervals in this interval exchange transformation.
   size_t size() const noexcept;

--- a/libintervalxt/intervalxt/interval_exchange_transformation.hpp
+++ b/libintervalxt/intervalxt/interval_exchange_transformation.hpp
@@ -32,13 +32,13 @@
 
 #include "external/spimpl/spimpl.h"
 
-#include "serializable.hpp"
 #include "lengths.hpp"
+#include "serializable.hpp"
 
 namespace intervalxt {
 
 class IntervalExchangeTransformation : boost::equality_comparable<IntervalExchangeTransformation>,
-  Serializable<IntervalExchangeTransformation> {
+                                       Serializable<IntervalExchangeTransformation> {
  public:
   IntervalExchangeTransformation();
   IntervalExchangeTransformation(std::shared_ptr<Lengths>, const std::vector<Label> &top, const std::vector<Label> &bottom);

--- a/libintervalxt/intervalxt/label.hpp
+++ b/libintervalxt/intervalxt/label.hpp
@@ -1,8 +1,8 @@
-/**********************************************************************
+/* ********************************************************************
  *  This file is part of intervalxt.
  *
- *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2019 - 2020 Vincent Delecroix
+ *        Copyright (C) 2019 - 2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
- *********************************************************************/
+ * *******************************************************************/
 
 #ifndef LIBINTERVALXT_LABEL_HPP
 #define LIBINTERVALXT_LABEL_HPP
@@ -25,11 +25,19 @@
 
 #include <boost/operators.hpp>
 
-#include "forward.hpp"
+#include "serializable.hpp"
 
 namespace intervalxt {
 
-class Label : public boost::equality_comparable<Label> {
+// A label identifying a pair of intervals in an interval exchange
+// transformation. The label itself carries no information about the length of
+// the interval, the Lengths object knows about this and other metadata.
+// Note that this class has on purpose no printing operator<< on purpose; the
+// label itself is just some random id, only the Lengths object knows a
+// meaningful name for this id which can be determined by calling
+// Lengths::render().
+class Label : public boost::equality_comparable<Label>,
+              public Serializable<Label> {
  public:
   Label();
   explicit Label(size_t id);
@@ -39,6 +47,7 @@ class Label : public boost::equality_comparable<Label> {
  private:
   size_t id;
 
+  friend Serialization<Label>;
   friend std::hash<Label>;
 };
 

--- a/libintervalxt/intervalxt/lengths.hpp
+++ b/libintervalxt/intervalxt/lengths.hpp
@@ -22,14 +22,16 @@
 #define LIBINTERVALXT_LENGTHS_HPP
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <gmpxx.h>
 #include <boost/type_erasure/any.hpp>
 #include <boost/type_erasure/member.hpp>
 
-#include "forward.hpp"
 #include "length.hpp"
+#include "erased/boost.hpp"
+#include "erased/serializable.hpp"
 
 namespace intervalxt {
 
@@ -43,6 +45,8 @@ BOOST_TYPE_ERASURE_MEMBER((has_member_cmp2), cmp, 2)
 BOOST_TYPE_ERASURE_MEMBER((has_member_get), get, 1)
 BOOST_TYPE_ERASURE_MEMBER((has_member_render), render, 1)
 
+struct LengthsSerialization;
+
 using LengthsInterface = boost::mpl::vector<
     boost::type_erasure::copy_constructible<>,
     has_member_push<void(Label)>,
@@ -54,10 +58,21 @@ using LengthsInterface = boost::mpl::vector<
     has_member_cmp2<int(Label, Label) const>,
     has_member_get<Length(Label) const>,
     has_member_render<std::string(Label) const>,
+    intervalxt::erased::is_serializable<LengthsSerialization>,
     boost::type_erasure::typeid_<>,
     boost::type_erasure::relaxed>;
 
 using Lengths = boost::type_erasure::any<LengthsInterface>;
+
+// See erased/README.md for details
+struct LengthsSerialization {
+  using Erased = Lengths;
+};
+
+template <typename T>
+::intervalxt::erased::Serializable<LengthsSerialization>::SerializableWrap<T> serializable(const T& unerased) {
+  return ::intervalxt::erased::Serializable<LengthsSerialization>::make(unerased);
+}
 
 }  // namespace intervalxt
 

--- a/libintervalxt/intervalxt/lengths.hpp
+++ b/libintervalxt/intervalxt/lengths.hpp
@@ -29,9 +29,9 @@
 #include <boost/type_erasure/any.hpp>
 #include <boost/type_erasure/member.hpp>
 
-#include "length.hpp"
 #include "erased/boost.hpp"
 #include "erased/serializable.hpp"
+#include "length.hpp"
 
 namespace intervalxt {
 

--- a/libintervalxt/intervalxt/sample/cereal.hpp
+++ b/libintervalxt/intervalxt/sample/cereal.hpp
@@ -1,8 +1,8 @@
 /**********************************************************************
  *  This file is part of intervalxt.
  *
- *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,47 +18,32 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-// This file forward declares all the types in the intervalxt namespace.
+#ifndef LIBINTERVALXT_SAMPLE_CEREAL_HPP
+#define LIBINTERVALXT_SAMPLE_CEREAL_HPP
 
-#ifndef LIBINTERVALXT_FORWARD_HPP
-#define LIBINTERVALXT_FORWARD_HPP
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/types/vector.hpp>
 
-#include <optional>
-#include <variant>
-
-#include "intervalxt.hpp"
+#include "lengths.hpp"
 
 namespace intervalxt {
 
-class Label;
-
-class IntervalExchangeTransformation;
-
-class DynamicalDecomposition;
-
-class Component;
-
-class HalfEdge;
-
-class Separatrix;
-
-struct DecompositionStep;
-
-struct InductionStep;
-
-class Connection;
-
-using Side = std::variant<Connection, HalfEdge>;
-
 template <typename T>
-class Serializable;
+struct Serialization<sample::Lengths<T>> {
+  template <typename Archive>
+  void save(Archive& archive, const sample::Lengths<T>& self) {
+    archive(cereal::make_nvp("lengths", self.lengths));
+    archive(cereal::make_nvp("stack", self.stack));
+  }
 
-template <typename T>
-struct Serialization;
+  template <typename Archive>
+  void load(Archive& archive, sample::Lengths<T>& self) {
+    archive(cereal::make_nvp("lengths", self.lengths));
+    archive(cereal::make_nvp("stack", self.stack));
+  }
+};
 
-template <typename T>
-class Implementation;
-
-}  // namespace intervalxt
+}
 
 #endif

--- a/libintervalxt/intervalxt/sample/cereal.hpp
+++ b/libintervalxt/intervalxt/sample/cereal.hpp
@@ -21,8 +21,8 @@
 #ifndef LIBINTERVALXT_SAMPLE_CEREAL_HPP
 #define LIBINTERVALXT_SAMPLE_CEREAL_HPP
 
-#include <cereal/cereal.hpp>
 #include <cereal/archives/json.hpp>
+#include <cereal/cereal.hpp>
 #include <cereal/types/vector.hpp>
 
 #include "lengths.hpp"
@@ -44,6 +44,6 @@ struct Serialization<sample::Lengths<T>> {
   }
 };
 
-}
+}  // namespace intervalxt
 
 #endif

--- a/libintervalxt/intervalxt/sample/detail/lengths.ipp
+++ b/libintervalxt/intervalxt/sample/detail/lengths.ipp
@@ -30,6 +30,9 @@
 #include "../arithmetic.hpp"
 #include "../lengths.hpp"
 
+// TODO: Remove
+#include "../../cereal.hpp"
+
 namespace intervalxt::sample {
 
 namespace {

--- a/libintervalxt/intervalxt/sample/detail/lengths.ipp
+++ b/libintervalxt/intervalxt/sample/detail/lengths.ipp
@@ -30,9 +30,6 @@
 #include "../arithmetic.hpp"
 #include "../lengths.hpp"
 
-// TODO: Remove
-#include "../../cereal.hpp"
-
 namespace intervalxt::sample {
 
 namespace {

--- a/libintervalxt/intervalxt/sample/lengths.hpp
+++ b/libintervalxt/intervalxt/sample/lengths.hpp
@@ -32,7 +32,7 @@
 namespace intervalxt::sample {
 
 template <typename T>
-class Lengths {
+class Lengths : public Serializable<Lengths<T>> {
  public:
   Lengths();
   explicit Lengths(const std::vector<T>&);
@@ -59,6 +59,8 @@ class Lengths {
  private:
   T& at(Label);
   const T& at(Label) const;
+
+  friend Serialization<Lengths<T>>;
 
   std::vector<Label> stack;
   std::vector<T> lengths;

--- a/libintervalxt/intervalxt/serializable.hpp
+++ b/libintervalxt/intervalxt/serializable.hpp
@@ -50,7 +50,6 @@ class Serializable {
   friend void load_minimal(const Archive& archive, T& self, const S& value) { Serialization<T>().load(archive, self, value); }
 };
 
-}  // namespace flatsurf
+}  // namespace intervalxt
 
 #endif
-

--- a/libintervalxt/intervalxt/serializable.hpp
+++ b/libintervalxt/intervalxt/serializable.hpp
@@ -1,0 +1,56 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  Flatsurf is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_SERIALIZABLE_HPP
+#define LIBINTERVALXT_SERIALIZABLE_HPP
+
+#include "forward.hpp"
+
+namespace intervalxt {
+
+// Common base class to add Cereal serialization.
+// This is needed for generic classes since we cannot currently tell cereal to
+// pick up free save/load functions if they are generic. (This is essentially
+// the Barton-Nackman trick to go from a free function with limited
+// specialization possibilities to the more powerful partial specialization
+// that types provide.)
+template <typename T>
+class Serializable {
+  template <bool Condition>
+  using If = std::enable_if_t<Condition, bool>;
+
+  template <typename Archive>
+  static constexpr bool is_minimal = !std::is_same_v<void, decltype(std::declval<Serialization<T>>().save(std::declval<const Archive&>(), std::declval<const T&>()))>;
+
+ public:
+  template <typename Archive, bool Enable = !is_minimal<Archive>, If<Enable> = true>
+  friend void save(Archive& archive, const T& self) { Serialization<T>().save(archive, self); }
+  template <typename Archive, bool Enable = !is_minimal<Archive>, If<Enable> = true>
+  friend void load(Archive& archive, T& self) { Serialization<T>().load(archive, self); }
+
+  template <typename Archive, bool Enable = is_minimal<Archive>, If<Enable> = true>
+  friend auto save_minimal(const Archive& archive, const T& self) { return Serialization<T>().save(archive, self); }
+  template <typename Archive, typename S, bool Enable = is_minimal<Archive>, If<Enable> = true>
+  friend void load_minimal(const Archive& archive, T& self, const S& value) { Serialization<T>().load(archive, self, value); }
+};
+
+}  // namespace flatsurf
+
+#endif
+

--- a/libintervalxt/src/Makefile.am
+++ b/libintervalxt/src/Makefile.am
@@ -1,47 +1,58 @@
 lib_LTLIBRARIES = libintervalxt.la
 
 libintervalxt_la_SOURCES =                         \
-	rational_linear_subspace.cc                \
-	label.cc                                   \
-	interval_exchange_transformation.cc        \
-	dynamical_decomposition.cc                 \
 	component.cc                               \
-	lengths_with_connections.cc                \
 	component_state.cc                         \
 	connection.cc                              \
-	separatrix.cc                              \
-	half_edge.cc                               \
+	decomposition_state.cc                     \
 	decomposition_step.cc                      \
+	dynamical_decomposition.cc                 \
+	half_edge.cc                               \
 	induction_step.cc                          \
-	decomposition_state.cc
+	interval_exchange_transformation.cc        \
+	label.cc                                   \
+	lengths_with_connections.cc                \
+	rational_linear_subspace.cc                \
+	separatrix.cc
 
 libintervalxt_la_LDFLAGS = -version-info $(libintervalxt_version_info)
 
 nobase_pkginclude_HEADERS =                                       \
+	../intervalxt/cereal.hpp                                  \
 	../intervalxt/component.hpp                               \
 	../intervalxt/connection.hpp                              \
 	../intervalxt/cppyy.hpp                                   \
 	../intervalxt/decomposition_step.hpp                      \
 	../intervalxt/dynamical_decomposition.hpp                 \
-	../intervalxt/external/spimpl/spimpl.h                    \
+	../intervalxt/erased/boost.hpp                            \
+	../intervalxt/erased/cereal.hpp                           \
+	../intervalxt/erased/detail/cereal.hpp                    \
+	../intervalxt/erased/detail/serializable.hpp              \
+	../intervalxt/erased/detail/unparen.hpp                   \
+	../intervalxt/erased/forward.hpp                          \
+	../intervalxt/erased/serializable.hpp                     \
 	../intervalxt/external/gmpxxll/mpz_class.hpp              \
-	../intervalxt/forward.hpp                                 \
+	../intervalxt/external/spimpl/spimpl.h                    \
 	../intervalxt/fmt.hpp                                     \
+	../intervalxt/forward.hpp                                 \
 	../intervalxt/half_edge.hpp                               \
 	../intervalxt/induction_step.hpp                          \
 	../intervalxt/interval_exchange_transformation.hpp        \
 	../intervalxt/label.hpp                                   \
 	../intervalxt/length.hpp                                  \
-	../intervalxt/lengths.hpp                                 \
 	../intervalxt/length_with_coefficients.hpp                \
-	../intervalxt/separatrix.hpp                              \
-	../intervalxt/sample/lengths.hpp                          \
-	../intervalxt/sample/detail/lengths.ipp                   \
+	../intervalxt/lengths.hpp                                 \
 	../intervalxt/sample/arithmetic.hpp                       \
-	../intervalxt/sample/mpz-arithmetic.hpp                   \
+	../intervalxt/sample/cereal.hpp                           \
+	../intervalxt/sample/detail/lengths.ipp                   \
 	../intervalxt/sample/e-antic-arithmetic.hpp               \
 	../intervalxt/sample/exact-real-arithmetic.hpp            \
-	../intervalxt/sample/rational-arithmetic.hpp
+	../intervalxt/sample/lengths.hpp                          \
+	../intervalxt/sample/mpz-arithmetic.hpp                   \
+	../intervalxt/sample/rational-arithmetic.hpp              \
+	../intervalxt/separatrix.hpp                              \
+	../intervalxt/serializable.hpp
+
 
 noinst_HEADERS =                                                  \
 	impl/component.impl.hpp                                   \

--- a/libintervalxt/src/interval_exchange_transformation.cc
+++ b/libintervalxt/src/interval_exchange_transformation.cc
@@ -222,6 +222,10 @@ bool IntervalExchangeTransformation::swapped() const noexcept {
   return impl->swap;
 }
 
+std::shared_ptr<const Lengths> IntervalExchangeTransformation::lengths() const {
+  return impl->lengths;
+}
+
 size_t IntervalExchangeTransformation::size() const noexcept {
   return impl->top.size();
 }

--- a/libintervalxt/src/lengths_with_connections.cc
+++ b/libintervalxt/src/lengths_with_connections.cc
@@ -23,6 +23,7 @@
 #include "../intervalxt/label.hpp"
 
 #include "impl/decomposition_state.hpp"
+#include "impl/forward.hpp"
 #include "impl/lengths_with_connections.hpp"
 
 #include "util/assert.ipp"

--- a/libintervalxt/test/Makefile.am
+++ b/libintervalxt/test/Makefile.am
@@ -1,10 +1,11 @@
-check_PROGRAMS = rational_linear_subspace label interval_exchange_transformation dynamical_decomposition
+check_PROGRAMS = rational_linear_subspace label interval_exchange_transformation dynamical_decomposition cereal
 TESTS = $(check_PROGRAMS)
 
 rational_linear_subspace_SOURCES = rational_linear_subspace.test.cc main.cc
 label_SOURCES = label.test.cc main.cc
 interval_exchange_transformation_SOURCES = interval_exchange_transformation.test.cc main.cc
 dynamical_decomposition_SOURCES = dynamical_decomposition.test.cc main.cc
+cereal_SOURCES = cereal.test.cc main.cc
 
 # We vendor the header-only library Cereal (serialization with C++ to be able
 # to run the tests even when cereal is not installed.

--- a/libintervalxt/test/cereal.test.cc
+++ b/libintervalxt/test/cereal.test.cc
@@ -37,7 +37,6 @@
 #include "../intervalxt/sample/lengths.hpp"
 
 #include "../intervalxt/erased/cereal.hpp"
-#include "../intervalxt/erased/serializable.hpp"
 
 LIBINTERVALXT_ERASED_REGISTER((::intervalxt::LengthsSerialization), (::intervalxt::sample::Lengths<int>))
 

--- a/libintervalxt/test/cereal.test.cc
+++ b/libintervalxt/test/cereal.test.cc
@@ -1,0 +1,104 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2019-2020 Vincent Delecroix
+ *        Copyright (C) 2019-2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#include <memory>
+#include <vector>
+
+#include <boost/type_erasure/any_cast.hpp>
+
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/archives/json.hpp>
+
+#include "external/catch2/single_include/catch2/catch.hpp"
+
+#include "../intervalxt/interval_exchange_transformation.hpp"
+#include "../intervalxt/label.hpp"
+#include "../intervalxt/length.hpp"
+#include "../intervalxt/lengths.hpp"
+#include "../intervalxt/sample/lengths.hpp"
+#include "../intervalxt/sample/cereal.hpp"
+#include "../intervalxt/cereal.hpp"
+
+#include "../intervalxt/erased/cereal.hpp"
+#include "../intervalxt/erased/serializable.hpp"
+
+LIBINTERVALXT_ERASED_REGISTER((::intervalxt::LengthsSerialization), (::intervalxt::sample::Lengths<int>))
+
+using cereal::JSONInputArchive;
+using cereal::JSONOutputArchive;
+
+using IntLengths = ::intervalxt::sample::Lengths<int>;
+
+namespace intervalxt::test {
+
+template <typename T>
+T test_serialization(const T& x, const std::function<bool(const T&, const T&)> equality = [](const T& lhs, const T& rhs) { return lhs == rhs; }) {
+  std::stringstream s;
+
+  {
+    JSONOutputArchive archive(s);
+    archive(cereal::make_nvp("serializedTo", x));
+  }
+
+  T y;
+  {
+    JSONInputArchive archive(s);
+    archive(cereal::make_nvp("serializedTo", y));
+  }
+
+  CAPTURE(x);
+  CAPTURE(s.str());
+  CAPTURE(y);
+  REQUIRE(equality(x, y));
+
+  return y;
+}
+
+TEST_CASE("Serialization of Label", "[cereal][label]") {
+  test_serialization(Label());
+  test_serialization(Label(1337));
+}
+
+TEST_CASE("Serialization of Lengths", "[cereal][lengths]") {
+  SECTION("Serialization of Lengths Without Type Erasure") {
+    IntLengths lengths({1, 2, 3});
+    test_serialization(lengths);
+  }
+
+  SECTION("Serialization of Lengths With Type Erasure") {
+    const auto equality = [](const Lengths& lhs, const Lengths& rhs) {
+      return boost::type_erasure::any_cast<IntLengths>(lhs)
+        == boost::type_erasure::any_cast<IntLengths>(rhs);
+    };
+
+    IntLengths unerased({1, 2, 3});
+    Lengths erased = unerased;
+    test_serialization<Lengths>(erased, equality);
+  }
+}
+
+TEST_CASE("Serialization of IntervalExchangeTransformation", "[cereal][interval_exchange_transformation]") {
+  auto&& [lengths, a, b, c, d] = IntLengths::make(18, 3, 1, 1);
+
+  test_serialization(IntervalExchangeTransformation());
+  test_serialization(IntervalExchangeTransformation(std::make_shared<Lengths>(lengths), {a, b, c, d}, {d, a, b, c}));
+}
+
+}  // namespace

--- a/libintervalxt/test/cereal.test.cc
+++ b/libintervalxt/test/cereal.test.cc
@@ -23,18 +23,18 @@
 
 #include <boost/type_erasure/any_cast.hpp>
 
-#include <cereal/types/polymorphic.hpp>
 #include <cereal/archives/json.hpp>
+#include <cereal/types/polymorphic.hpp>
 
 #include "external/catch2/single_include/catch2/catch.hpp"
 
+#include "../intervalxt/cereal.hpp"
 #include "../intervalxt/interval_exchange_transformation.hpp"
 #include "../intervalxt/label.hpp"
 #include "../intervalxt/length.hpp"
 #include "../intervalxt/lengths.hpp"
-#include "../intervalxt/sample/lengths.hpp"
 #include "../intervalxt/sample/cereal.hpp"
-#include "../intervalxt/cereal.hpp"
+#include "../intervalxt/sample/lengths.hpp"
 
 #include "../intervalxt/erased/cereal.hpp"
 #include "../intervalxt/erased/serializable.hpp"
@@ -49,7 +49,8 @@ using IntLengths = ::intervalxt::sample::Lengths<int>;
 namespace intervalxt::test {
 
 template <typename T>
-T test_serialization(const T& x, const std::function<bool(const T&, const T&)> equality = [](const T& lhs, const T& rhs) { return lhs == rhs; }) {
+T test_serialization(
+    const T& x, const std::function<bool(const T&, const T&)> equality = [](const T& lhs, const T& rhs) { return lhs == rhs; }) {
   std::stringstream s;
 
   {
@@ -84,8 +85,7 @@ TEST_CASE("Serialization of Lengths", "[cereal][lengths]") {
 
   SECTION("Serialization of Lengths With Type Erasure") {
     const auto equality = [](const Lengths& lhs, const Lengths& rhs) {
-      return boost::type_erasure::any_cast<IntLengths>(lhs)
-        == boost::type_erasure::any_cast<IntLengths>(rhs);
+      return boost::type_erasure::any_cast<IntLengths>(lhs) == boost::type_erasure::any_cast<IntLengths>(rhs);
     };
 
     IntLengths unerased({1, 2, 3});
@@ -101,4 +101,4 @@ TEST_CASE("Serialization of IntervalExchangeTransformation", "[cereal][interval_
   test_serialization(IntervalExchangeTransformation(std::make_shared<Lengths>(lengths), {a, b, c, d}, {d, a, b, c}));
 }
 
-}  // namespace
+}  // namespace intervalxt::test

--- a/pyintervalxt/configure.ac
+++ b/pyintervalxt/configure.ac
@@ -32,6 +32,7 @@ AS_IF([test "x$with_pytest" != "xno" && test "x$have_python" = "xyes"],
        with_pytest=yes
        AS_IF([$PYTHON -c 'import pytest'], , AC_MSG_ERROR([pytest for make check not found; run --without-pytest to disable Python tests in make check]))
        AS_IF([$PYTHON -c 'import cppyy'], , AC_MSG_ERROR([cppyy for make check not found; run --without-pytest to disable Python tests in make check]))
+       AS_IF([$PYTHON -c 'import cppyythonizations'], , AC_MSG_ERROR([cppyythonizations for make check not found; run --without-pytest to disable Python tests in make check]))
       ], [])
 AM_CONDITIONAL([HAVE_PYTEST], [test "x$with_pytest" = "xyes"])
 

--- a/pyintervalxt/src/pyintervalxt/__init__.py
+++ b/pyintervalxt/src/pyintervalxt/__init__.py
@@ -15,6 +15,7 @@ Pickling works::
 
     >>> from pickle import loads, dumps
     >>> loads(dumps(iet))
+    [a: 18] [b: 3] / [b] [a]
 
 """
 

--- a/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
+++ b/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
@@ -1,8 +1,8 @@
 ######################################################################
 #  This file is part of intervalxt.
 #
-#        Copyright (C) 2019 Vincent Delecroix
-#        Copyright (C) 2019 Julian Rüth
+#        Copyright (C) 2019-2020 Vincent Delecroix
+#        Copyright (C) 2019-2020 Julian Rüth
 #
 #  intervalxt is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -19,6 +19,8 @@
 #####################################################################
 
 import cppyy
+
+from cppyythonizations.pickling.cereal import enable_cereal
 
 # Importing cysignals after cppyy gives us proper stack traces on segfaults
 # whereas cppyy otherwise only reports "segmentation violation" (which is
@@ -48,6 +50,9 @@ def pretty_print(proxy, name):
 
 cppyy.py.add_pythonization(pretty_print, "intervalxt")
 
+cppyy.py.add_pythonization(lambda proxy, name: enable_cereal(proxy, name, ["intervalxt/cereal.hpp", "intervalxt/sample/cereal.hpp"]), "intervalxt")
+cppyy.py.add_pythonization(lambda proxy, name: enable_cereal(proxy, name, ["intervalxt/cereal.hpp", "intervalxt/sample/cereal.hpp"]), "intervalxt::sample")
+
 # Set EXTRA_CLING_ARGS="-I /usr/include" or wherever intervalxt/cppyy.hpp can
 # be resolved if the following line fails to find the header file.
 cppyy.include("intervalxt/cppyy.hpp")
@@ -56,6 +61,7 @@ from cppyy.gbl import intervalxt
 
 def IET(lengths, permutation):
     from cppyy.gbl import std
-    return intervalxt.makeIET(intervalxt.sample.Lengths[int](lengths), permutation)
+    lengths = intervalxt.sample.Lengths[int](lengths)
+    return intervalxt.makeIET(lengths, permutation)
 
 intervalxt.IET = IET

--- a/pyintervalxt/test/Makefile.am
+++ b/pyintervalxt/test/Makefile.am
@@ -1,14 +1,18 @@
-TESTS = interval_exchange_transformation.py
+TESTS = interval_exchange_transformation.py python-doctest.sh
 EXTRA_DIST = $(TESTS)
 
 AM_TESTS_ENVIRONMENT = . $(builddir)/test-env.sh;
 
 interval_exchange_transformation.py: test-env.sh
+python-doctest.sh: test-env.sh
 
 @VALGRIND_CHECK_RULES@
 
-BUILT_SOURCES = test-env.sh
-EXTRA_DIST += test-env.sh.in
-CLEANFILES = test-env.sh
+BUILT_SOURCES = test-env.sh python-doctest.sh
+EXTRA_DIST += test-env.sh.in python-doctest.sh.in
+CLEANFILES = test-env.sh python-doctest.sh
 $(builddir)/test-env.sh: $(srcdir)/test-env.sh.in Makefile
 	sed -e 's,[@]abs_srcdir[@],$(abs_srcdir),g' -e 's,[@]abs_builddir[@],$(abs_builddir),g' -e 's,[@]pythondir[@],$(pythondir),g' < $< > $@
+$(builddir)/python-doctest.sh: $(srcdir)/python-doctest.sh.in Makefile
+	sed -e 's,[@]srcdir[@],$(srcdir),g' < $< > $@
+	chmod +x $@

--- a/pyintervalxt/test/python-doctest.sh.in
+++ b/pyintervalxt/test/python-doctest.sh.in
@@ -1,22 +1,4 @@
-# -*- coding: utf-8 -*-
-r"""
-A Python Interface to libintervalxt
-
-EXAMPLES::
-
-    >>> from pyintervalxt import IET
-    >>> iet = IET((18, 3), (1, 0))
-    >>> iet
-    [a: 18] [b: 3] / [b] [a]
-    
-TESTS:
-
-Pickling works::
-
-    >>> from pickle import loads, dumps
-    >>> loads(dumps(iet))
-
-"""
+#!/bin/sh
 
 ######################################################################
 #  This file is part of intervalxt.
@@ -25,9 +7,9 @@ Pickling works::
 #        Copyright (C) 2019-2020 Julian Rüth
 #
 #  intervalxt is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
 #
 #  intervalxt is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -38,4 +20,7 @@ Pickling works::
 #  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
 #####################################################################
 
-from .cppyy_intervalxt import intervalxt, IET
+set -ex
+
+TARGETS=`grep -l '>>>' @srcdir@/../src/pyintervalxt/*.py`
+pytest -vv --doctest-modules $TARGETS

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ requirements:
     - clangdev ==8.0.0
 {%- endif %}
   host:
-{%- if name != "pyintervalxt" %}
+{%- if name in ["intervalxt", "libintervalxt"] %}
     # compile-time dependencies of libintervalxt
     - boost-cpp
     - e-antic 1.*
@@ -55,9 +55,10 @@ requirements:
     - gmp
     - ppl
 {%- endif %}
-{%- if name != "libintervalxt" %}
+{%- if name in ["intervalxt", "pyintervalxt"] %}
     - python
     - setuptools
+    - cppyythonizations
 {%- endif %}
 {%- if name == "pyintervalxt" %}
     - libintervalxt {{ version }} {{ target }}_{{ build_number }}


### PR DESCRIPTION
see #65

This only does basic types surrounding IntervalExchangeTransformation.
More complex objects such as ContourDecomposition will have to happen in
another PR.

The machinery for erased types in intervalxt/erased might eventually go
into a standalone header-only library as this might be of more general
interest.