### PR TITLE
Fix search paths in Python testing

### DIFF
--- a/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
+++ b/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
@@ -48,9 +48,8 @@ def pretty_print(proxy, name):
 
 cppyy.py.add_pythonization(pretty_print, "intervalxt")
 
-for path in os.environ.get('PYINTERVALXT_INCLUDE','').split(':'):
-    if path: cppyy.add_include_path(path)
-
+# Set EXTRA_CLING_ARGS="-I /usr/include" or wherever intervalxt/cppyy.hpp can
+# be resolved if the following line fails to find the header file.
 cppyy.include("intervalxt/cppyy.hpp")
 
 from cppyy.gbl import intervalxt

--- a/pyintervalxt/test/Makefile.am
+++ b/pyintervalxt/test/Makefile.am
@@ -11,4 +11,4 @@ BUILT_SOURCES = test-env.sh
 EXTRA_DIST += test-env.sh.in
 CLEANFILES = test-env.sh
 $(builddir)/test-env.sh: $(srcdir)/test-env.sh.in Makefile
-	sed -e 's,[@]srcdir[@],$(srcdir),g' -e 's,[@]builddir[@],$(builddir),g' -e 's,[@]pythondir[@],$(pythondir),g' < $< > $@
+	sed -e 's,[@]abs_srcdir[@],$(abs_srcdir),g' -e 's,[@]abs_builddir[@],$(abs_builddir),g' -e 's,[@]pythondir[@],$(pythondir),g' < $< > $@

--- a/pyintervalxt/test/test-env.sh.in
+++ b/pyintervalxt/test/test-env.sh.in
@@ -1,5 +1,7 @@
 #!/bin/sh
 
-export PYINTERVALXT_INCLUDE="@srcdir@/../../libintervalxt:@builddir@/../../libintervalxt/intervalxt"
-export LD_LIBRARY_PATH="@builddir@/../../libintervalxt/src/.libs/"
-export PYTHONPATH="@builddir@/../../pyintervalxt/src/:@pythondir@"
+# Resolve #include <intervalxt/*.hpp> relative to libintervalxt in the source tree and
+# resolve #include "intervalxt.hpp" relative to libintervalxt/intervalxt in the build tree.
+export EXTRA_CLING_ARGS="-I@abs_srcdir@/../../libintervalxt -I@abs_builddir@/../../libintervalxt/intervalxt $EXTRA_CLING_ARGS"
+export LD_LIBRARY_PATH="@abs_builddir@/../../libintervalxt/src/.libs/:$LD_LIBRARY_PATH"
+export PYTHONPATH="@abs_srcdir@/../src/:@pythondir@"


### PR DESCRIPTION
The PYINTERVALXT_INCLUDE we used before is appended to the default
search path. This is a problem when running in a local development
checkout of intervalxt: the global cppyy.hpp header is preferred over
the local one.

Fixes #78.