### PR TITLE
WIP: detect periodic renormalization for SAF0

### DIFF
--- a/libintervalxt/test/Makefile.am
+++ b/libintervalxt/test/Makefile.am
@@ -1,10 +1,11 @@
-check_PROGRAMS = rational_linear_subspace label interval_exchange_transformation dynamical_decomposition
+check_PROGRAMS = rational_linear_subspace label interval_exchange_transformation dynamical_decomposition saf_zero
 TESTS = $(check_PROGRAMS)
 
 rational_linear_subspace_SOURCES = rational_linear_subspace.test.cc main.cc
 label_SOURCES = label.test.cc main.cc
 interval_exchange_transformation_SOURCES = interval_exchange_transformation.test.cc main.cc
 dynamical_decomposition_SOURCES = dynamical_decomposition.test.cc main.cc
+saf_zero_SOURCES = saf_zero.test.cc
 
 # We vendor the header-only library Cereal (serialization with C++ to be able
 # to run the tests even when cereal is not installed.

--- a/libintervalxt/test/Makefile.am
+++ b/libintervalxt/test/Makefile.am
@@ -5,7 +5,7 @@ rational_linear_subspace_SOURCES = rational_linear_subspace.test.cc main.cc
 label_SOURCES = label.test.cc main.cc
 interval_exchange_transformation_SOURCES = interval_exchange_transformation.test.cc main.cc
 dynamical_decomposition_SOURCES = dynamical_decomposition.test.cc main.cc
-saf_zero_SOURCES = saf_zero.test.cc
+saf_zero_SOURCES = saf_zero.test.cc main.cc
 
 # We vendor the header-only library Cereal (serialization with C++ to be able
 # to run the tests even when cereal is not installed.

--- a/libintervalxt/test/saf_zero.test.cc
+++ b/libintervalxt/test/saf_zero.test.cc
@@ -1,8 +1,8 @@
 /**********************************************************************
  *  This file is part of intervalxt.
  *
- *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,6 +17,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
+
+#include <valarray>
 
 #include <e-antic/renfxx.h>
 #include <fmt/format.h>

--- a/libintervalxt/test/saf_zero.test.cc
+++ b/libintervalxt/test/saf_zero.test.cc
@@ -54,7 +54,7 @@ TEST_CASE("Cubic IET in H(3,1) with SAF=0") {
           renf_elem_class(K, "-5*A^2 + 22*A - 10"), renf_elem_class(K, "1/3*A^2 - 2*A + 3"));
   auto iet = IntervalExchangeTransformation(std::make_shared<Lengths>(lengths), {a, b, c, d, e, f, g}, {d, f, e, c, b, g, a});
 
-  auto s = iet.safInvariant()
+  auto s = iet.safInvariant();
   REQUIRE(s.min() == 0);
   REQUIRE(s.max() == 0);
 

--- a/libintervalxt/test/saf_zero.test.cc
+++ b/libintervalxt/test/saf_zero.test.cc
@@ -55,7 +55,8 @@ TEST_CASE("Cubic IET in H(3,1) with SAF=0") {
   auto iet = IntervalExchangeTransformation(std::make_shared<Lengths>(lengths), {a, b, c, d, e, f, g}, {d, f, e, c, b, g, a});
 
   auto s = iet.safInvariant()
-  REQUIRE(s.min() == 0 && s.max() == 0);
+  REQUIRE(s.min() == 0);
+  REQUIRE(s.max() == 0);
 
   auto decomposition = DynamicalDecomposition(iet);
   }

--- a/libintervalxt/test/saf_zero.test.cc
+++ b/libintervalxt/test/saf_zero.test.cc
@@ -26,7 +26,6 @@
 
 #include "external/catch2/single_include/catch2/catch.hpp"
 
-#include "../intervalxt/induction_step.hpp"
 #include "../intervalxt/interval_exchange_transformation.hpp"
 #include "../intervalxt/label.hpp"
 #include "../intervalxt/connection.hpp"
@@ -35,8 +34,6 @@
 #include "../intervalxt/fmt.hpp"
 #include "../intervalxt/sample/e-antic-arithmetic.hpp"
 #include "../intervalxt/sample/lengths.hpp"
-#include "../intervalxt/sample/mpz-arithmetic.hpp"
-#include "../intervalxt/sample/rational-arithmetic.hpp"
 
 using eantic::renf_class;
 using eantic::renf_elem_class;
@@ -44,20 +41,25 @@ using Result = ::intervalxt::DecompositionStep::Result;
 
 namespace intervalxt::test {
 
-TEST_CASE("Cubic IET in H(3,1) with SAF=0") {
+TEST_CASE("Cubic IET in H(3,1) with SAF=0", "[saf_zero_interval_exchange_transformation]") {
   using namespace eantic;
   using EAnticLengths = sample::Lengths<renf_elem_class>;
-  auto K = renf_class::make("A^3 - 6*A^2 + 9*A - 3", "a", "3.87 +/- 0.01");
+  auto K = renf_class::make("A^3 - 6*A^2 + 9*A - 3", "A", "3.87 +/- 0.01");
   auto&& [lengths, a, b, c, d, e, f, g] = EAnticLengths::make(renf_elem_class(K, "-A^2 + 4*A"),
           renf_elem_class(K, "1/3*A^2 - A - 1"), renf_elem_class(K, "40/3*A^2 - 61*A + 36"),
           renf_elem_class(K, "-25/3*A^2 + 38*A - 22"), renf_elem_class(K, "1/3*A^2 - 5"),
           renf_elem_class(K, "-5*A^2 + 22*A - 10"), renf_elem_class(K, "1/3*A^2 - 2*A + 3"));
-  auto iet = IntervalExchangeTransformation(std::make_shared<Lengths>(lengths), {a, b, c, d, e, f, g}, {d, f, e, c, b, g, a});
+  auto iet = IntervalExchangeTransformation(std::make_shared<Lengths>(lengths), {a, b, c, d, e, f, g}, {g, f, d, c, e, b, a});
 
-  auto s = iet.safInvariant();
-  REQUIRE(s.min() == 0);
-  REQUIRE(s.max() == 0);
+  SECTION("SAF should be zero") {
+    auto s = iet.safInvariant();
+    REQUIRE(s.min() == 0);
+    REQUIRE(s.max() == 0);
+  }
 
   auto decomposition = DynamicalDecomposition(iet);
+  REQUIRE(decomposition.components().size() == 1);
+  auto component = decomposition.components()[0];
+  auto step0 = component.decompositionStep();
   }
-}
+}  // namespace intervalxt::test

--- a/libintervalxt/test/saf_zero.test.cc
+++ b/libintervalxt/test/saf_zero.test.cc
@@ -1,0 +1,60 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2019 Vincent Delecroix
+ *        Copyright (C) 2019 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#include <e-antic/renfxx.h>
+#include <fmt/format.h>
+#include <boost/logic/tribool.hpp>
+
+#include "external/catch2/single_include/catch2/catch.hpp"
+
+#include "../intervalxt/induction_step.hpp"
+#include "../intervalxt/interval_exchange_transformation.hpp"
+#include "../intervalxt/label.hpp"
+#include "../intervalxt/connection.hpp"
+#include "../intervalxt/decomposition_step.hpp"
+#include "../intervalxt/dynamical_decomposition.hpp"
+#include "../intervalxt/fmt.hpp"
+#include "../intervalxt/sample/e-antic-arithmetic.hpp"
+#include "../intervalxt/sample/lengths.hpp"
+#include "../intervalxt/sample/mpz-arithmetic.hpp"
+#include "../intervalxt/sample/rational-arithmetic.hpp"
+
+using eantic::renf_class;
+using eantic::renf_elem_class;
+using Result = ::intervalxt::DecompositionStep::Result;
+
+namespace intervalxt::test {
+
+TEST_CASE("Cubic IET in H(3,1) with SAF=0") {
+  using namespace eantic;
+  using EAnticLengths = sample::Lengths<renf_elem_class>;
+  auto K = renf_class::make("A^3 - 6*A^2 + 9*A - 3", "a", "3.87 +/- 0.01");
+  auto&& [lengths, a, b, c, d, e, f, g] = EAnticLengths::make(renf_elem_class(K, "-A^2 + 4*A"),
+          renf_elem_class(K, "1/3*A^2 - A - 1"), renf_elem_class(K, "40/3*A^2 - 61*A + 36"),
+          renf_elem_class(K, "-25/3*A^2 + 38*A - 22"), renf_elem_class(K, "1/3*A^2 - 5"),
+          renf_elem_class(K, "-5*A^2 + 22*A - 10"), renf_elem_class(K, "1/3*A^2 - 2*A + 3"));
+  auto iet = IntervalExchangeTransformation(std::make_shared<Lengths>(lengths), {a, b, c, d, e, f, g}, {d, f, e, c, b, g, a});
+
+  auto s = iet.safInvariant()
+  REQUIRE(s.min() == 0 && s.max() == 0);
+
+  auto decomposition = DynamicalDecomposition(iet);
+  }
+}


### PR DESCRIPTION
Boshernitzan criterion does not work for interval exchanges with SAF=0. For an iet with SAF=0, we should disable Boshernitzan criterion when computing the `DynamicalDecomposition` and instead rely on detecting complete periodicity of the renormalization.

- Fixes #86 
- Will not be a complete solution until #87 has one