### PR TITLE
Compute rational coefficients for several elements at a time

### DIFF
--- a/libintervalxt/intervalxt/cppyy.hpp
+++ b/libintervalxt/intervalxt/cppyy.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "dynamical_decomposition.hpp"
+#include "induction_step.hpp"
 #include "interval_exchange_transformation.hpp"
 #include "label.hpp"
 #include "lengths.hpp"

--- a/libintervalxt/intervalxt/cppyy.hpp
+++ b/libintervalxt/intervalxt/cppyy.hpp
@@ -23,7 +23,6 @@
 
 #include <iosfwd>
 #include <memory>
-#include <valarray>
 #include <vector>
 
 #include "cereal.hpp"

--- a/libintervalxt/intervalxt/cppyy.hpp
+++ b/libintervalxt/intervalxt/cppyy.hpp
@@ -62,7 +62,7 @@ class Lengths : public ::intervalxt::sample::Lengths<typename V::value_type> {
 };
 
 template <typename L>
-auto IntervalExchangeTransformation(L& lengths, const std::vector<int>& permutation) {
+auto IntervalExchangeTransformation(L &lengths, const std::vector<int> &permutation) {
   ::intervalxt::Lengths erasedLengths = lengths;
   auto top = lengths.labels();
   std::vector<Label> bottom;
@@ -71,7 +71,7 @@ auto IntervalExchangeTransformation(L& lengths, const std::vector<int>& permutat
   return ::intervalxt::IntervalExchangeTransformation(std::make_shared<::intervalxt::Lengths>(erasedLengths), top, bottom);
 }
 
-}  // namespace intervalxt
+}  // namespace intervalxt::cppyy
 
 namespace intervalxt {
 

--- a/libintervalxt/intervalxt/interval_exchange_transformation.hpp
+++ b/libintervalxt/intervalxt/interval_exchange_transformation.hpp
@@ -57,7 +57,7 @@ class IntervalExchangeTransformation : boost::equality_comparable<IntervalExchan
   void swap();
 
   // Return the Sah-Arnoux-Fathi invariant
-  std::valarray<mpq_class> safInvariant() const;
+  std::vector<mpq_class> safInvariant() const;
 
   // Return whether there is no periodic trajectory via Boshernitzan's
   // algorithm.

--- a/libintervalxt/intervalxt/interval_exchange_transformation.hpp
+++ b/libintervalxt/intervalxt/interval_exchange_transformation.hpp
@@ -84,7 +84,13 @@ class IntervalExchangeTransformation : boost::equality_comparable<IntervalExchan
   // Return whether swap() has been called an odd number of times.
   bool swapped() const noexcept;
 
-  bool operator==(const IntervalExchangeTransformation &) const;
+  // Return whether this interval exchange transformation and rhs have the same
+  // underlying permutation and lengths. Unlike operator==, this ignores the
+  // exact labels.
+  bool equivalent(const IntervalExchangeTransformation &rhs) const;
+
+  // Return whether this interval exchange transformation and rhs have the same labels and the same lengths.
+  bool operator==(const IntervalExchangeTransformation &rhs) const;
 
   friend std::ostream &operator<<(std::ostream &, const IntervalExchangeTransformation &);
 

--- a/libintervalxt/intervalxt/lengths.hpp
+++ b/libintervalxt/intervalxt/lengths.hpp
@@ -61,7 +61,7 @@ struct LengthsInterface : boost::mpl::vector<
                               has_member_pop<void()>,
                               has_member_subtract<void(Label)>,
                               has_member_subtract_repeated<Label(Label)>,
-                              has_member_coefficients<std::vector<mpq_class>(Label) const>,
+                              has_member_coefficients<std::vector<std::vector<mpq_class>>(const std::vector<Label>&) const>,
                               has_member_cmp1<int(Label) const>,
                               has_member_cmp2<int(Label, Label) const>,
                               has_member_get<Length(Label) const>,

--- a/libintervalxt/intervalxt/sample/coefficients.hpp
+++ b/libintervalxt/intervalxt/sample/coefficients.hpp
@@ -1,0 +1,98 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_SAMPLE_COEFFICIENTS_HPP
+#define LIBINTERVALXT_SAMPLE_COEFFICIENTS_HPP
+
+#include <gmpxx.h>
+
+#include <type_traits>
+#include <vector>
+
+namespace intervalxt::sample {
+
+namespace {
+
+// Given an element x returns the coefficients of x over some appropriate
+// rational vector space. E.g., given a number field element, writes that
+// element in some power basis and returns the coefficients over this basis.
+// You must provide a specialization of this class for each type that you want
+// to use in a sample::Lengths. See the other files in this directory for some
+// examples.
+template <typename S = void, typename _ = void>
+class Coefficients {
+  template <typename>
+  static constexpr bool false_t = false;
+
+ public:
+  using T = S;
+
+  std::vector<std::vector<mpq_class>> operator()(const std::vector<T>& elements) {
+    static_assert(false_t<T>, "operator() returning rational coefficients of this element not implemented");
+    throw std::logic_error("not implemented: Coefficients::operator()");
+  }
+};
+
+// A convenience implementation of the general Coefficients which applies to
+// tuples of fixed length instead of vectors.
+template <>
+class Coefficients<void, void> {
+  template <typename T, std::size_t... I>
+  static auto makeTuple(const std::vector<T>& elements, std::index_sequence<I...>) {
+    return std::make_tuple(elements[I]...);
+  }
+
+ public:
+  // Helper struct that applies C::operator() to the arguments.
+  template <typename C>
+  struct Map {
+    template <typename... Args>
+    auto operator()(Args&&... elements) {
+      constexpr int N = sizeof...(Args);
+      if constexpr (N == 0) {
+        return std::tuple<>();
+      } else {
+        using T = typename std::decay_t<typename std::tuple_element<0, std::tuple<Args...>>::type>;
+        auto coefficients = C()(std::vector<T>{std::forward<Args>(elements)...});
+        return makeTuple(coefficients, std::make_index_sequence<N>());
+      }
+    }
+  };
+
+  // Apply Coefficients<T>::operator() to the arguments, i.e., return a tuple
+  // of vectors of rational numbers representing the coefficients of the
+  // elements in some common vector space.
+  template <typename... Args>
+  auto operator()(Args&&... elements) {
+    constexpr int N = sizeof...(Args);
+    if constexpr (N == 0) {
+      return std::tuple<>();
+    } else {
+      using T = typename std::decay_t<typename std::tuple_element<0, std::tuple<Args...>>::type>;
+      return Map<Coefficients<T>>()(std::forward<Args>(elements)...);
+    }
+  }
+};
+
+}  // namespace
+
+}  // namespace intervalxt::sample
+
+#endif

--- a/libintervalxt/intervalxt/sample/coefficients.hpp
+++ b/libintervalxt/intervalxt/sample/coefficients.hpp
@@ -45,13 +45,13 @@ class Coefficients {
   using T = S;
 
   std::vector<std::vector<mpq_class>> operator()(const std::vector<T>& elements) {
-    static_assert(false_t<T>, "operator() returning rational coefficients of this element not implemented");
-    throw std::logic_error("not implemented: Coefficients::operator()");
+    static_assert(false_t<T>, "operator() returning rational coefficients of this element not implemented; did you include the appropriate coefficients header?");
+    throw std::logic_error("not implemented: Coefficients::operator(); did you include the appropriate coefficients header?");
   }
 };
 
-// A convenience implementation of the general Coefficients which applies to
-// tuples of fixed length instead of vectors.
+// A wrapper for the general Coefficients which applies to tuples of fixed
+// length instead of vectors.
 template <>
 class Coefficients<void, void> {
   template <typename T, std::size_t... I>

--- a/libintervalxt/intervalxt/sample/detail/lengths.ipp
+++ b/libintervalxt/intervalxt/sample/detail/lengths.ipp
@@ -57,7 +57,8 @@ template <typename T, typename FloorDivision, typename Coefficients>
 Lengths<T, FloorDivision, Coefficients>::Lengths(const std::vector<T>& lengths) :
   stack(),
   lengths(lengths) {
-  assert(std::all_of(lengths.begin(), lengths.end(), [](const auto& length) { return length >= 0; }) && "all Lengths must be non-negative");
+  if (std::any_of(begin(lengths), end(lengths), [](const auto& length) { return length < 0; }))
+    throw std::invalid_argument("all lengths must be non-negative");
 }
 
 template <typename T, typename FloorDivision, typename Coefficients>

--- a/libintervalxt/intervalxt/sample/element_coefficients.hpp
+++ b/libintervalxt/intervalxt/sample/element_coefficients.hpp
@@ -2,7 +2,7 @@
  *  This file is part of intervalxt.
  *
  *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2019-2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,24 +18,38 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-#ifndef LIBINTERVALXT_SAMPLE_EXACT_REAL_ARITHMETIC_HPP
-#define LIBINTERVALXT_SAMPLE_EXACT_REAL_ARITHMETIC_HPP
+#ifndef LIBINTERVALXT_SAMPLE_ELEMENT_COEFFICIENTS_HPP
+#define LIBINTERVALXT_SAMPLE_ELEMENT_COEFFICIENTS_HPP
 
 #include <exact-real/element.hpp>
 
-#include "arithmetic.hpp"
+#include "coefficients.hpp"
 
 namespace intervalxt::sample {
 
+namespace {
+
 template <typename Ring>
-struct Arithmetic<exactreal::Element<Ring>> {
+struct Coefficients<exactreal::Element<Ring>> {
   using T = exactreal::Element<Ring>;
 
-  static std::vector<mpq_class> coefficients(const T& value) { return value.template coefficients<mpq_class>(); }
-  static auto floorDivision(const T& divident, const T& divisor) {
-    return divident.floordiv(divisor);
+  std::vector<std::vector<mpq_class>> operator()(const std::vector<T>& elements) {
+    if (elements.size() == 0)
+      return {};
+
+    auto parent = elements[0].module();
+    for (auto& x : elements)
+      parent = span(parent, x.module());
+
+    std::vector<std::vector<mpq_class>> ret;
+    for (auto x : elements)
+      ret.push_back(x.promote(parent).template coefficients<mpq_class>());
+
+    return ret;
   }
 };
+
+}  // namespace
 
 }  // namespace intervalxt::sample
 

--- a/libintervalxt/intervalxt/sample/element_floor_division.hpp
+++ b/libintervalxt/intervalxt/sample/element_floor_division.hpp
@@ -1,0 +1,44 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_SAMPLE_ELEMENT_FLOOR_DIVISION_HPP
+#define LIBINTERVALXT_SAMPLE_ELEMENT_FLOOR_DIVISION_HPP
+
+#include <exact-real/element.hpp>
+
+#include "floor_division.hpp"
+
+namespace intervalxt::sample {
+
+namespace {
+
+template <typename Ring>
+struct FloorDivision<exactreal::Element<Ring>> {
+  using T = exactreal::Element<Ring>;
+
+  mpz_class operator()(const T& divident, const T& divisor) {
+    return divident.floordiv(divisor);
+  }
+};
+
+}  // namespace
+
+}  // namespace intervalxt::sample
+
+#endif

--- a/libintervalxt/intervalxt/sample/floor_division.hpp
+++ b/libintervalxt/intervalxt/sample/floor_division.hpp
@@ -1,0 +1,54 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_SAMPLE_FLOOR_DIVISION_HPP
+#define LIBINTERVALXT_SAMPLE_FLOOR_DIVISION_HPP
+
+#include <gmpxx.h>
+
+#include <type_traits>
+
+namespace intervalxt::sample {
+
+namespace {
+
+// Implements floor divisions for a type S. You must provide a specialization
+// of this struct for each type that you want to use in a sample::Lengths. See
+// the other files in this directory for some examples.
+template <typename S, typename R = std::conditional_t<std::is_integral_v<S>, S, mpz_class>, typename _ = void>
+struct FloorDivision {
+ private:
+  template <typename>
+  static constexpr bool false_t = false;
+
+ public:
+  using T = S;
+
+  R operator()(const T&, const T&) {
+    static_assert(false_t<T>, "operator() performing a floor division not implemented for this type");
+    throw std::logic_error("not implemented: FloorDivision::operator()");
+  }
+};
+
+}  // namespace
+
+}  // namespace intervalxt::sample
+
+#endif

--- a/libintervalxt/intervalxt/sample/floor_division.hpp
+++ b/libintervalxt/intervalxt/sample/floor_division.hpp
@@ -42,8 +42,8 @@ struct FloorDivision {
   using T = S;
 
   R operator()(const T&, const T&) {
-    static_assert(false_t<T>, "operator() performing a floor division not implemented for this type");
-    throw std::logic_error("not implemented: FloorDivision::operator()");
+    static_assert(false_t<T>, "operator() performing a floor division not implemented for this type; did you include the appropriate floor division header?");
+    throw std::logic_error("not implemented: FloorDivision::operator(); did you include the appropriate floor division header?");
   }
 };
 

--- a/libintervalxt/intervalxt/sample/integer_coefficients.hpp
+++ b/libintervalxt/intervalxt/sample/integer_coefficients.hpp
@@ -1,0 +1,49 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_SAMPLE_INTEGER_COEFFICIENTS_HPP
+#define LIBINTERVALXT_SAMPLE_INTEGER_COEFFICIENTS_HPP
+
+#include <gmpxxll/mpz_class.hpp>
+
+#include "coefficients.hpp"
+
+namespace intervalxt::sample {
+
+namespace {
+
+template <typename S>
+struct Coefficients<S, typename std::enable_if<std::is_integral_v<S>>::type> {
+  using T = S;
+
+  std::vector<std::vector<mpq_class>> operator()(const std::vector<T>& elements) {
+    std::vector<std::vector<mpq_class>> ret;
+    for (auto x : elements)
+      ret.push_back({mpq_class(gmpxxll::mpz_class(x))});
+
+    return ret;
+  }
+};
+
+}  // namespace
+
+}  // namespace intervalxt::sample
+
+#endif

--- a/libintervalxt/intervalxt/sample/integer_floor_division.hpp
+++ b/libintervalxt/intervalxt/sample/integer_floor_division.hpp
@@ -2,6 +2,7 @@
  *  This file is part of intervalxt.
  *
  *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,25 +18,25 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-#ifndef LIBINTERVALXT_SAMPLE_MPZ_ARITHMETIC_HPP
-#define LIBINTERVALXT_SAMPLE_MPZ_ARITHMETIC_HPP
+#ifndef LIBINTERVALXT_SAMPLE_INTEGER_FLOOR_DIVISION_HPP
+#define LIBINTERVALXT_SAMPLE_INTEGER_FLOOR_DIVISION_HPP
 
-#include <string>
-
-#include "arithmetic.hpp"
+#include "floor_division.hpp"
 
 namespace intervalxt::sample {
 
-template <>
-struct Arithmetic<long long int> {
-  using T = long long int;
+namespace {
 
-  static std::vector<mpq_class> coefficients(const T& value) {
-    return std::vector{mpq_class(std::to_string(value).c_str())};
+template <typename S>
+struct FloorDivision<S, S, typename std::enable_if<std::is_integral_v<S>>::type> {
+  using T = S;
+
+  T operator()(const T divident, const T divisor) {
+    return divident / divisor;
   }
-
-  static T floorDivision(const T& divident, const T& divisor) { return divident / divisor; }
 };
+
+}  // namespace
 
 }  // namespace intervalxt::sample
 

--- a/libintervalxt/intervalxt/sample/lengths.hpp
+++ b/libintervalxt/intervalxt/sample/lengths.hpp
@@ -76,6 +76,9 @@ class Lengths : public Serializable<Lengths<T>> {
   std::vector<T> lengths;
 };
 
+template <typename T>
+Lengths(const std::vector<T>&) -> Lengths<T>;
+
 }  // namespace
 
 }  // namespace intervalxt::sample

--- a/libintervalxt/intervalxt/sample/lengths.hpp
+++ b/libintervalxt/intervalxt/sample/lengths.hpp
@@ -2,7 +2,7 @@
  *  This file is part of intervalxt.
  *
  *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2019-2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -29,10 +29,14 @@
 
 #include "../label.hpp"
 #include "../lengths.hpp"
+#include "coefficients.hpp"
+#include "floor_division.hpp"
 
 namespace intervalxt::sample {
 
-template <typename T>
+namespace {
+
+template <typename T, typename FloorDivision = FloorDivision<T>, typename Coefficients = Coefficients<T>>
 class Lengths : public Serializable<Lengths<T>> {
  public:
   Lengths();
@@ -53,7 +57,7 @@ class Lengths : public Serializable<Lengths<T>> {
   int cmp(Label, Label) const;
   void subtract(Label);
   Label subtractRepeated(Label);
-  std::vector<mpq_class> coefficients(Label) const;
+  std::vector<std::vector<mpq_class>> coefficients(const std::vector<Label>&) const;
   std::string render(Label) const;
   T get(Label) const;
   ::intervalxt::Lengths only(const std::unordered_set<Label>&) const;
@@ -71,6 +75,8 @@ class Lengths : public Serializable<Lengths<T>> {
   std::vector<Label> stack;
   std::vector<T> lengths;
 };
+
+}  // namespace
 
 }  // namespace intervalxt::sample
 

--- a/libintervalxt/intervalxt/sample/mpq_coefficients.hpp
+++ b/libintervalxt/intervalxt/sample/mpq_coefficients.hpp
@@ -18,25 +18,31 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-#ifndef LIBINTERVALXT_SAMPLE_MPZ_ARITHMETIC_HPP
-#define LIBINTERVALXT_SAMPLE_MPZ_ARITHMETIC_HPP
+#ifndef LIBINTERVALXT_SAMPLE_RATIONAL_COEFFICIENTS_HPP
+#define LIBINTERVALXT_SAMPLE_RATIONAL_COEFFICIENTS_HPP
 
 #include <gmpxx.h>
 
-#include "arithmetic.hpp"
+#include "coefficients.hpp"
 
 namespace intervalxt::sample {
 
+namespace {
+
 template <>
-struct Arithmetic<mpz_class> {
-  using T = mpz_class;
+struct Coefficients<mpq_class> {
+  using T = mpq_class;
 
-  static std::vector<mpq_class> coefficients(const T& value) {
-    return std::vector{mpq_class(value)};
+  std::vector<std::vector<mpq_class>> operator()(const std::vector<T>& elements) {
+    std::vector<std::vector<mpq_class>> ret;
+    for (auto x : elements)
+      ret.push_back({x});
+
+    return ret;
   }
-
-  static mpz_class floorDivision(const T& divident, const T& divisor) { return divident / divisor; }
 };
+
+}  // namespace
 
 }  // namespace intervalxt::sample
 

--- a/libintervalxt/intervalxt/sample/mpq_floor_division.hpp
+++ b/libintervalxt/intervalxt/sample/mpq_floor_division.hpp
@@ -2,7 +2,7 @@
  *  This file is part of intervalxt.
  *
  *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2019-2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,32 +18,27 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-#ifndef LIBINTERVALXT_SAMPLE_ARITHMETIC_HPP
-#define LIBINTERVALXT_SAMPLE_ARITHMETIC_HPP
+#ifndef LIBINTERVALXT_SAMPLE_MPQ_FLOOR_DIVISION_HPP
+#define LIBINTERVALXT_SAMPLE_MPQ_FLOOR_DIVISION_HPP
 
 #include <gmpxx.h>
 
-#include <type_traits>
-#include <vector>
+#include "floor_division.hpp"
 
 namespace intervalxt::sample {
 
-template <typename Arithmetic>
-using QuotientFloorDivision = typename std::invoke_result_t<decltype(&Arithmetic::floorDivision), const typename Arithmetic::T&, const typename Arithmetic::T&>;
+namespace {
 
-template <typename S, typename _ = void>
-struct Arithmetic {
-  using T = S;
+template <>
+struct FloorDivision<mpq_class> {
+  using T = mpq_class;
 
-  static std::vector<mpq_class> coefficients(const T& value) {
-    if constexpr (std::is_same_v<T, long long> || std::is_same_v<T, unsigned long long>) {
-      return std::vector<mpq_class>{mpq_class(std::to_string(value))};
-    } else {
-      return std::vector<mpq_class>{value};
-    }
+  mpz_class operator()(const T& divident, const T& divisor) {
+    return (divident.get_num() * divisor.get_den()) / (divident.get_den() * divisor.get_num());
   }
-  static auto floorDivision(const T& divident, const T& divisor) { return divident / divisor; }
 };
+
+}  // namespace
 
 }  // namespace intervalxt::sample
 

--- a/libintervalxt/intervalxt/sample/mpz_coefficients.hpp
+++ b/libintervalxt/intervalxt/sample/mpz_coefficients.hpp
@@ -1,8 +1,8 @@
 /**********************************************************************
  *  This file is part of intervalxt.
  *
- *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2019-2020 Vincent Delecroix
+ *                      2019-2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,25 +18,31 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-#ifndef LIBINTERVALXT_SAMPLE_RATIONAL_ARITHMETIC_HPP
-#define LIBINTERVALXT_SAMPLE_RATIONAL_ARITHMETIC_HPP
+#ifndef LIBINTERVALXT_SAMPLE_MPZ_COEFFICIENTS_HPP
+#define LIBINTERVALXT_SAMPLE_MPZ_COEFFICIENTS_HPP
 
 #include <gmpxx.h>
 
-#include "arithmetic.hpp"
+#include "coefficients.hpp"
 
 namespace intervalxt::sample {
 
+namespace {
+
 template <>
-struct Arithmetic<mpq_class> {
-  using T = mpq_class;
+struct Coefficients<mpz_class> {
+  using T = mpz_class;
 
-  static std::vector<mpq_class> coefficients(const T& value) { return std::vector{value}; }
+  std::vector<std::vector<mpq_class>> operator()(const std::vector<T>& elements) {
+    std::vector<std::vector<mpq_class>> ret;
+    for (auto x : elements)
+      ret.push_back({x});
 
-  static mpz_class floorDivision(const T& divident, const T& divisor) {
-    return (divident.get_num() * divisor.get_den()) / (divident.get_den() * divisor.get_num());
+    return ret;
   }
 };
+
+}  // namespace
 
 }  // namespace intervalxt::sample
 

--- a/libintervalxt/intervalxt/sample/mpz_floor_division.hpp
+++ b/libintervalxt/intervalxt/sample/mpz_floor_division.hpp
@@ -1,0 +1,45 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2019-2020 Vincent Delecroix
+ *                      2019-2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_SAMPLE_MPZ_FLOOR_DIVISION_HPP
+#define LIBINTERVALXT_SAMPLE_MPZ_FLOOR_DIVISION_HPP
+
+#include <gmpxx.h>
+
+#include "floor_division.hpp"
+
+namespace intervalxt::sample {
+
+namespace {
+
+template <>
+struct FloorDivision<mpz_class> {
+  using T = mpz_class;
+
+  mpz_class operator()(const T& divident, const T& divisor) {
+    return divident / divisor;
+  }
+};
+
+}  // namespace
+
+}  // namespace intervalxt::sample
+
+#endif

--- a/libintervalxt/intervalxt/sample/renf_elem_coefficients.hpp
+++ b/libintervalxt/intervalxt/sample/renf_elem_coefficients.hpp
@@ -1,0 +1,73 @@
+/**********************************************************************
+ *  This file is part of intervalxt.
+ *
+ *        Copyright (C) 2019 Vincent Delecroix
+ *        Copyright (C) 2019-2020 Julian Rüth
+ *
+ *  intervalxt is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  intervalxt is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBINTERVALXT_SAMPLE_RENF_ELEM_COEFFICIENTS_HPP
+#define LIBINTERVALXT_SAMPLE_RENF_ELEM_COEFFICIENTS_HPP
+
+#include <e-antic/renfxx.h>
+
+#include "coefficients.hpp"
+
+namespace intervalxt::sample {
+
+namespace {
+
+template <>
+struct Coefficients<eantic::renf_elem_class> {
+  using T = eantic::renf_elem_class;
+
+  std::vector<std::vector<mpq_class>> operator()(const std::vector<T>& elements) {
+    if (elements.size() == 0)
+      return {};
+
+    auto parent = elements[0].parent().shared_from_this();
+    for (auto& x : elements) {
+      if (x.is_rational())
+        continue;
+      if (parent->degree() == 1)
+        parent = x.parent().shared_from_this();
+      if (*parent != x.parent())
+        throw std::logic_error("not implemented: cannot coerce elements living in different number fields to a common parent yet");
+    }
+
+    std::vector<std::vector<mpq_class>> ret;
+    for (auto x : elements) {
+      x = eantic::renf_elem_class(parent, x);
+
+      std::vector<mpq_class> coefficients;
+      const auto den = x.den();
+      for (auto num : x.num_vector()) {
+        auto entry = mpq_class(num, den);
+        entry.canonicalize();
+        coefficients.push_back(entry);
+      }
+
+      ret.push_back(coefficients);
+    }
+
+    return ret;
+  }
+};
+
+}  // namespace
+
+}  // namespace intervalxt::sample
+
+#endif

--- a/libintervalxt/intervalxt/sample/renf_elem_floor_division.hpp
+++ b/libintervalxt/intervalxt/sample/renf_elem_floor_division.hpp
@@ -2,7 +2,7 @@
  *  This file is part of intervalxt.
  *
  *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2019-2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,32 +18,27 @@
  *  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
  *********************************************************************/
 
-#ifndef LIBINTERVALXT_SAMPLE_E_ANTIC_ARITHMETIC_HPP
-#define LIBINTERVALXT_SAMPLE_E_ANTIC_ARITHMETIC_HPP
+#ifndef LIBINTERVALXT_SAMPLE_RENF_ELEM_FLOOR_DIVISION_HPP
+#define LIBINTERVALXT_SAMPLE_RENF_ELEM_FLOOR_DIVISION_HPP
 
 #include <e-antic/renfxx.h>
 
-#include "arithmetic.hpp"
+#include "floor_division.hpp"
 
 namespace intervalxt::sample {
 
+namespace {
+
 template <>
-struct Arithmetic<eantic::renf_elem_class> {
+struct FloorDivision<eantic::renf_elem_class> {
   using T = eantic::renf_elem_class;
 
-  static std::vector<mpq_class> coefficients(const T& value) {
-    std::vector<mpq_class> ret;
-    auto d = value.den();
-    for (auto i : value.num_vector()) {
-      auto dat = mpq_class(i, d);
-      dat.canonicalize();
-      ret.push_back(dat);
-    }
-    return ret;
+  mpz_class operator()(const T& divident, const T& divisor) {
+    return (divident / divisor).floor();
   }
-
-  static auto floorDivision(const T& divident, const T& divisor) { return (divident / divisor).floor(); }
 };
+
+}  // namespace
 
 }  // namespace intervalxt::sample
 

--- a/libintervalxt/src/Makefile.am
+++ b/libintervalxt/src/Makefile.am
@@ -43,15 +43,21 @@ nobase_pkginclude_HEADERS =                                       \
 	../intervalxt/length.hpp                                  \
 	../intervalxt/length_with_coefficients.hpp                \
 	../intervalxt/lengths.hpp                                 \
-	../intervalxt/sample/arithmetic.hpp                       \
 	../intervalxt/sample/cereal.hpp                           \
+	../intervalxt/sample/coefficients.hpp                     \
 	../intervalxt/sample/detail/lengths.ipp                   \
-	../intervalxt/sample/e-antic-arithmetic.hpp               \
-	../intervalxt/sample/exact-real-arithmetic.hpp            \
+	../intervalxt/sample/element_coefficients.hpp             \
+	../intervalxt/sample/element_floor_division.hpp           \
+	../intervalxt/sample/floor_division.hpp                   \
+	../intervalxt/sample/integer_coefficients.hpp             \
+	../intervalxt/sample/integer_floor_division.hpp           \
 	../intervalxt/sample/lengths.hpp                          \
-	../intervalxt/sample/long-long-int-arithmetic.hpp         \
-	../intervalxt/sample/mpz-arithmetic.hpp                   \
-	../intervalxt/sample/rational-arithmetic.hpp              \
+	../intervalxt/sample/mpq_coefficients.hpp                 \
+	../intervalxt/sample/mpq_floor_division.hpp               \
+	../intervalxt/sample/mpz_coefficients.hpp                 \
+	../intervalxt/sample/mpz_floor_division.hpp               \
+	../intervalxt/sample/renf_elem_coefficients.hpp           \
+	../intervalxt/sample/renf_elem_floor_division.hpp         \
 	../intervalxt/separatrix.hpp                              \
 	../intervalxt/serializable.hpp
 

--- a/libintervalxt/src/component.cc
+++ b/libintervalxt/src/component.cc
@@ -25,7 +25,6 @@
 #include <boost/logic/tribool.hpp>
 #include <ostream>
 #include <unordered_set>
-#include <valarray>
 #include <variant>
 #include <vector>
 

--- a/libintervalxt/src/impl/interval_exchange_transformation.impl.hpp
+++ b/libintervalxt/src/impl/interval_exchange_transformation.impl.hpp
@@ -37,20 +37,20 @@ class Implementation<IntervalExchangeTransformation> {
   static IntervalExchangeTransformation withLengths(const IntervalExchangeTransformation&, const std::function<std::shared_ptr<Lengths>(std::shared_ptr<Lengths>)>&);
   static std::string render(const IntervalExchangeTransformation&, Label);
 
-  // Return the translation vector for the label i
-  // The output is a vector of mpq_class with respect to the irrational basis
+  // Return the translation vectors for the labels on top.
+  // Each output is a vector of mpq_class with respect to the irrational basis
   // used for the lengths of the iet.
-  std::valarray<mpq_class> translation(Label) const;
+  std::vector<std::vector<mpq_class>> translations() const;
 
-  std::valarray<mpq_class> coefficients(Label) const;
+  // Return the coefficient vectors for the labels on top.
+  std::vector<std::vector<mpq_class>> coefficients() const;
 
-  std::valarray<mpq_class> saf() const;
+  std::vector<mpq_class> saf() const;
   bool saf0() const;
 
   std::list<Interval> top;
   std::list<Interval> bottom;
   std::shared_ptr<Lengths> lengths;
-  const size_t degree;
   SimilarityTracker similarityTracker = {};
   bool swap = false;
 };

--- a/libintervalxt/src/impl/lengths_with_connections.hpp
+++ b/libintervalxt/src/impl/lengths_with_connections.hpp
@@ -42,7 +42,7 @@ class LengthsWithConnections {
   void pop();
   void subtract(Label);
   Label subtractRepeated(Label);
-  std::vector<mpq_class> coefficients(Label) const;
+  std::vector<std::vector<mpq_class>> coefficients(const std::vector<Label>&) const;
   int cmp(Label) const;
   int cmp(Label, Label) const;
   Length get(Label) const;

--- a/libintervalxt/src/interval_exchange_transformation.cc
+++ b/libintervalxt/src/interval_exchange_transformation.cc
@@ -2,7 +2,7 @@
  *  This file is part of intervalxt.
  *
  *        Copyright (C) 2019 Vincent Delecroix
- *        Copyright (C) 2019 Julian Rüth
+ *        Copyright (C) 2019-2020 Julian Rüth
  *
  *  intervalxt is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,7 +26,6 @@
 #include <algorithm>
 #include <list>
 #include <unordered_set>
-#include <valarray>
 
 #include "../intervalxt/fmt.hpp"
 #include "../intervalxt/induction_step.hpp"
@@ -44,11 +43,11 @@ namespace intervalxt {
 namespace {
 
 template <typename T>
-std::valarray<T> wedge(std::valarray<T> v1, std::valarray<T> v2) {
+std::vector<T> wedge(std::vector<T> v1, std::vector<T> v2) {
   CHECK_ARGUMENT(v1.size() == v2.size(), "vectors must have same size but " << v1.size() << " != " << v2.size());
 
   size_t d = v1.size();
-  std::valarray<T> res(d * (d - 1) / 2);
+  std::vector<T> res(d * (d - 1) / 2);
   if (d == 0) return res;
   size_t k = 0;
   for (size_t i = 0; i < d - 1; i++)
@@ -58,6 +57,20 @@ std::valarray<T> wedge(std::valarray<T> v1, std::valarray<T> v2) {
     }
 
   return res;
+}
+
+std::vector<mpq_class>& operator+=(std::vector<mpq_class>& lhs, const std::vector<mpq_class>& rhs) {
+  ASSERT(lhs.size() == rhs.size(), "cannot add vectors of different size");
+  for (size_t i = 0; i < lhs.size(); i++)
+    lhs[i] += rhs[i];
+  return lhs;
+}
+
+std::vector<mpq_class>& operator-=(std::vector<mpq_class>& lhs, const std::vector<mpq_class>& rhs) {
+  ASSERT(lhs.size() == rhs.size(), "cannot add vectors of different size");
+  for (size_t i = 0; i < lhs.size(); i++)
+    lhs[i] -= rhs[i];
+  return lhs;
 }
 
 }  // namespace
@@ -100,32 +113,29 @@ bool IntervalExchangeTransformation::zorichInduction() {
   return lengths.cmp(*begin(impl->top), *begin(impl->bottom)) == 0;
 }
 
-std::valarray<mpq_class> IntervalExchangeTransformation::safInvariant() const {
+std::vector<mpq_class> IntervalExchangeTransformation::safInvariant() const {
   return impl->saf();
 }
 
 bool IntervalExchangeTransformation::boshernitzanNoPeriodicTrajectory() const {
-  if (impl->degree <= 1) {
-    return false;
-  } else {
-    if (impl->saf0()) {
-      // When SAF = 0 the Boshernitzan is never going to report "true".
-      // https://github.com/flatsurf/intervalxt/issues/86
-      return false;
-    }
+  const auto translations = impl->translations();
 
-    // Build the QQ-module of relations between translations, that is the space generated
-    // by integer vectors (a0, ..., an) such that a0 t0 + a1 t1 + ... + an tn = 0
-    // Note: it would be nice to access the dimension of the module
-    // in some more straightforward way...
-    vector<vector<mpq_class>> translations(impl->degree);
-    for (auto& l : impl->top) {
-      const auto t = impl->translation(l);
-      for (size_t d = 0; d < impl->degree; d++)
-        translations[d].push_back(t[d]);
-    }
-    return not RationalLinearSubspace::fromEquations(translations).hasNonZeroNonNegativeVector();
-  }
+  if (translations[0].size() <= 1)
+    return false;
+
+  // When SAF = 0 the Boshernitzan is never going to report "true".
+  // https://github.com/flatsurf/intervalxt/issues/86
+  if (impl->saf0())
+    return false;
+
+  // Build the QQ-module of relations between translations, that is the space generated
+  // by integer vectors (a0, ..., an) such that a0 t0 + a1 t1 + ... + an tn = 0
+  std::vector<std::vector<mpq_class>> relations(translations[0].size());
+  for (auto& t : translations)
+    for (size_t d = 0; d < t.size(); d++)
+      relations[d].push_back(t[d]);
+
+  return not RationalLinearSubspace::fromEquations(relations).hasNonZeroNonNegativeVector();
 }
 
 InductionStep IntervalExchangeTransformation::induce(int limit) {
@@ -305,8 +315,7 @@ bool IntervalExchangeTransformation::operator==(const IntervalExchangeTransforma
 Implementation<IntervalExchangeTransformation>::Implementation(std::shared_ptr<Lengths> lengths, const vector<Label>& top, const vector<Label>& bottom) :
   top(top | rx::transform([](const Label label) { return Interval(label); }) | rx::to_list()),
   bottom(bottom | rx::transform([](const Label label) { return Interval(label); }) | rx::to_list()),
-  lengths(std::move(lengths)),
-  degree(top.size() == 0 ? 0 : this->lengths->coefficients(*top.begin()).size()) {
+  lengths(std::move(lengths)) {
   ASSERT(top.size() == bottom.size(), "top and bottom must have the same length");
 
   ASSERT(std::unordered_set<Label>(begin(top), end(top)).size() == std::unordered_set<Label>(begin(bottom), end(bottom)).size(), "top and bottom must consist of the same labels");
@@ -322,25 +331,23 @@ Implementation<IntervalExchangeTransformation>::Implementation(std::shared_ptr<L
     }
   }
 
-  ASSERT(std::all_of(top.begin(), top.end(), [&](Label label) { return this->lengths->coefficients(label).size() == degree; }), "Degrees of elements over Q do not match; expected " << degree);
   ASSERT(std::all_of(top.begin(), top.end(), [&](Label label) { return static_cast<bool>(this->lengths->get(label)); }), "all lengths must be positive");
 }
 
-std::valarray<mpq_class> Implementation<IntervalExchangeTransformation>::saf() const {
-  if (degree == 1) {
-    // empty vector for integers or rationals
+std::vector<mpq_class> Implementation<IntervalExchangeTransformation>::saf() const {
+  const auto coefficients = this->coefficients();
+  const auto translations = this->translations();
+
+  const auto degree = coefficients[0].size();
+  if (degree <= 1)
     return {};
-  } else {
-    std::valarray<mpq_class> w;
 
-    w.resize(degree * (degree - 1) / 2);
+  std::vector<mpq_class> w(degree * (degree - 1) / 2);
 
-    for (auto& i : top) {
-      w += wedge(coefficients(i), translation(i));
-    }
+  for (const auto& [c, t] : rx::zip(coefficients, translations))
+    w += wedge(c, t);
 
-    return w;
-  }
+  return w;
 }
 
 bool Implementation<IntervalExchangeTransformation>::saf0() const {
@@ -348,29 +355,35 @@ bool Implementation<IntervalExchangeTransformation>::saf0() const {
   return std::none_of(begin(saf), end(saf), [](const auto& x) { return x; });
 }
 
-std::valarray<mpq_class> Implementation<IntervalExchangeTransformation>::coefficients(Label label) const {
-  auto coefficients = lengths->coefficients(label);
-  ASSERT(degree == coefficients.size(), "All Lengths must have the same number of Rational Coefficients but " << lengths->get(label) << " reported " << coefficients.size() << " instead of " << degree);
-  return std::valarray<mpq_class>(coefficients.data(), coefficients.size());
+std::vector<std::vector<mpq_class>> Implementation<IntervalExchangeTransformation>::coefficients() const {
+  return lengths->coefficients(top | rx::transform([](const auto& interval) { return static_cast<Label>(interval); }) | rx::to_vector());
 }
 
-// Return the translation vector for the label i The output is a vector of
-// mpq_class with respect to the irrational basis used for the lengths of
-// the iet.
-std::valarray<mpq_class> Implementation<IntervalExchangeTransformation>::translation(Label i) const {
-  std::valarray<mpq_class> translation(degree);
+std::vector<std::vector<mpq_class>> Implementation<IntervalExchangeTransformation>::translations() const {
+  const auto coefficients = this->coefficients();
+  std::unordered_map<Label, std::vector<mpq_class>> labelToCoefficient;
+  for (const auto& [label, coefficient] : rx::zip(top, coefficients))
+    labelToCoefficient[label] = coefficient;
 
-  for (auto& j : top) {
-    if (j == i) break;
-    translation -= coefficients(j);
+  std::vector<std::vector<mpq_class>> translations;
+  for (const auto& label : top) {
+    std::vector<mpq_class> translation(coefficients[0].size());
+    for (auto& t : top) {
+      if (t == label)
+        break;
+      translation -= labelToCoefficient.at(t);
+    }
+
+    for (auto& b : bottom) {
+      if (b == label)
+        break;
+      translation += labelToCoefficient.at(b);
+    }
+
+    translations.push_back(translation);
   }
 
-  for (auto& j : bottom) {
-    if (j == i) break;
-    translation += coefficients(j);
-  }
-
-  return translation;
+  return translations;
 }
 
 IntervalExchangeTransformation Implementation<IntervalExchangeTransformation>::withLengths(const IntervalExchangeTransformation& iet, const std::function<std::shared_ptr<Lengths>(std::shared_ptr<Lengths>)>& createLengths) {

--- a/libintervalxt/src/interval_exchange_transformation.cc
+++ b/libintervalxt/src/interval_exchange_transformation.cc
@@ -300,6 +300,27 @@ std::optional<IntervalExchangeTransformation> IntervalExchangeTransformation::re
   }
 }
 
+bool IntervalExchangeTransformation::equivalent(const IntervalExchangeTransformation& rhs) const {
+  if (size() != rhs.size())
+    return false;
+
+  const auto permutation = [](const std::vector<Label>& top, const std::vector<Label>& bottom) {
+    return bottom | rx::transform([&](const auto& b) { return std::find(begin(top), end(top), b) - begin(top); }) | rx::to_vector();
+  };
+
+  if (permutation(top(), bottom()) != permutation(rhs.top(), rhs.bottom()))
+    return false;
+
+  const auto topLengths = [](const std::vector<Label>& top, const auto& lengths) {
+    return top | rx::transform([&](const auto& label) { return lengths->get(label); }) | rx::to_vector();
+  };
+
+  if (topLengths(top(), impl->lengths) != topLengths(rhs.top(), rhs.impl->lengths))
+    return false;
+
+  return true;
+}
+
 bool IntervalExchangeTransformation::operator==(const IntervalExchangeTransformation& rhs) const {
   const std::vector<Label> labels = impl->top | rx::transform([](const auto& interval) { return interval.label; }) | rx::to_vector();
   if (impl->top != rhs.impl->top || impl->bottom != rhs.impl->bottom)

--- a/libintervalxt/src/lengths_with_connections.cc
+++ b/libintervalxt/src/lengths_with_connections.cc
@@ -91,8 +91,8 @@ Label LengthsWithConnections::subtractRepeated(Label minuend) {
   return ret;
 }
 
-std::vector<mpq_class> LengthsWithConnections::coefficients(Label label) const {
-  return lengths->coefficients(label);
+std::vector<std::vector<mpq_class>> LengthsWithConnections::coefficients(const std::vector<Label>& labels) const {
+  return lengths->coefficients(labels);
 }
 
 int LengthsWithConnections::cmp(Label label) const {

--- a/libintervalxt/test/cereal.test.cc
+++ b/libintervalxt/test/cereal.test.cc
@@ -31,6 +31,8 @@
 #include "../intervalxt/length.hpp"
 #include "../intervalxt/lengths.hpp"
 #include "../intervalxt/sample/cereal.hpp"
+#include "../intervalxt/sample/integer_coefficients.hpp"
+#include "../intervalxt/sample/integer_floor_division.hpp"
 #include "../intervalxt/sample/lengths.hpp"
 #include "external/catch2/single_include/catch2/catch.hpp"
 

--- a/libintervalxt/test/dynamical_decomposition.test.cc
+++ b/libintervalxt/test/dynamical_decomposition.test.cc
@@ -28,8 +28,11 @@
 #include "../intervalxt/dynamical_decomposition.hpp"
 #include "../intervalxt/fmt.hpp"
 #include "../intervalxt/interval_exchange_transformation.hpp"
-#include "../intervalxt/sample/e-antic-arithmetic.hpp"
+#include "../intervalxt/sample/integer_coefficients.hpp"
+#include "../intervalxt/sample/integer_floor_division.hpp"
 #include "../intervalxt/sample/lengths.hpp"
+#include "../intervalxt/sample/renf_elem_coefficients.hpp"
+#include "../intervalxt/sample/renf_elem_floor_division.hpp"
 #include "external/catch2/single_include/catch2/catch.hpp"
 
 using eantic::renf_class;

--- a/libintervalxt/test/interval_exchange_transformation.test.cc
+++ b/libintervalxt/test/interval_exchange_transformation.test.cc
@@ -26,10 +26,16 @@
 #include "../intervalxt/induction_step.hpp"
 #include "../intervalxt/interval_exchange_transformation.hpp"
 #include "../intervalxt/label.hpp"
-#include "../intervalxt/sample/e-antic-arithmetic.hpp"
+#include "../intervalxt/sample/integer_coefficients.hpp"
+#include "../intervalxt/sample/integer_floor_division.hpp"
 #include "../intervalxt/sample/lengths.hpp"
-#include "../intervalxt/sample/mpz-arithmetic.hpp"
-#include "../intervalxt/sample/rational-arithmetic.hpp"
+#include "../intervalxt/sample/mpq_coefficients.hpp"
+#include "../intervalxt/sample/mpq_floor_division.hpp"
+#include "../intervalxt/sample/mpz_coefficients.hpp"
+#include "../intervalxt/sample/mpz_floor_division.hpp"
+#include "../intervalxt/sample/renf_elem_coefficients.hpp"
+#include "../intervalxt/sample/renf_elem_floor_division.hpp"
+#include "../src/external/rx-ranges/include/rx/ranges.hpp"
 #include "external/catch2/single_include/catch2/catch.hpp"
 
 using std::pair;
@@ -308,21 +314,19 @@ TEST_CASE("Computation of SAF Invariant", "[interval_exchange_transformation][sa
 
       auto&& [lengths, a, b, c, d] = EAnticLengths::make(x / 2, x * x - mpq_class(1, 13), 4 * x / 7 - 1, 2 * one);
       auto iet = IET(lengths, {a, b, c, d}, {d, c, b, a});
+      CAPTURE(iet);
 
       auto v = iet.safInvariant();
+      CAPTURE(v);
 
-      REQUIRE((v.min() != 0 || v.max() != 0));
+      REQUIRE((v | rx::any_of([](const auto& x) { return x != 0; })));
 
       int sign = 1;
 
       for (int i = 0; i < 10; i++) {
         iet.zorichInduction();
         iet.swap();
-        std::valarray<mpq_class> vv;
-        if (sign)
-          vv = -iet.safInvariant();
-        else
-          vv = iet.safInvariant();
+        auto vv = iet.safInvariant() | rx::transform([&](const auto& x) { return sign ? -x : x; }) | rx::to_vector();
         REQUIRE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
         sign ^= 1;
       }
@@ -334,20 +338,19 @@ TEST_CASE("Computation of SAF Invariant", "[interval_exchange_transformation][sa
 
       auto&& [lengths, a, b, c, d] = EAnticLengths::make(2 * x / 17, 5 * x * x / 3 - mpq_class(1, 18), 5 * x * x / 2 - 3, 3 * one);
       auto iet = IET(lengths, {a, b, c, d}, {d, c, b, a});
+      CAPTURE(iet);
 
       auto v = iet.safInvariant();
-      REQUIRE((v.min() != 0 || v.max() != 0));
+      CAPTURE(v);
+
+      REQUIRE((v | rx::any_of([](const auto& x) { return x != 0; })));
 
       int sign = 1;
 
       for (int i = 0; i < 10; i++) {
         iet.zorichInduction();
         iet.swap();
-        std::valarray<mpq_class> vv;
-        if (sign)
-          vv = -iet.safInvariant();
-        else
-          vv = iet.safInvariant();
+        auto vv = iet.safInvariant() | rx::transform([&](const auto& x) { return sign ? -x : x; }) | rx::to_vector();
         REQUIRE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
         sign ^= 1;
       }
@@ -360,15 +363,17 @@ TEST_CASE("Computation of SAF Invariant", "[interval_exchange_transformation][sa
 
       auto&& [lengths, a, b, c, d, e, f, g] = EAnticLengths::make(x + 1, x * x - x - 1, x * x, x, x, one, one);
       auto iet = IET(lengths, {a, b, c, d, e, f, g}, {b, e, d, g, f, c, a});
+      CAPTURE(iet);
 
       auto v = iet.safInvariant();
-      REQUIRE(v.min() == 0);
-      REQUIRE(v.max() == 0);
+      CAPTURE(v);
+
+      REQUIRE((v | rx::all_of([](const auto& x) { return x == 0; })));
 
       for (int i = 0; i < 10; i++) {
         iet.zorichInduction();
         iet.swap();
-        std::valarray<mpq_class> vv = iet.safInvariant();
+        const auto vv = iet.safInvariant();
         REQUIRE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
       }
     }
@@ -380,15 +385,17 @@ TEST_CASE("Computation of SAF Invariant", "[interval_exchange_transformation][sa
 
       auto&& [lengths, a, b, c, d, e, f, g, h, i] = EAnticLengths::make(x.pow(4) - x.pow(3), 2 * x.pow(3) - x.pow(4), x.pow(3), x.pow(2), x.pow(2), x, x, one, one);
       auto iet = IET(lengths, {a, b, c, d, e, f, g, h, i}, {b, e, d, g, f, i, h, c, a});
+      CAPTURE(iet);
 
       auto v = iet.safInvariant();
-      REQUIRE(v.min() == 0);
-      REQUIRE(v.max() == 0);
+      CAPTURE(v);
+
+      REQUIRE((v | rx::all_of([](const auto& x) { return x == 0; })));
 
       for (int i = 0; i < 10; i++) {
         iet.zorichInduction();
         iet.swap();
-        std::valarray<mpq_class> vv = iet.safInvariant();
+        const auto vv = iet.safInvariant();
         REQUIRE(std::equal(std::begin(v), std::end(v), std::begin(vv), std::end(vv)));
       }
     }

--- a/news/coefficients.rst
+++ b/news/coefficients.rst
@@ -1,0 +1,17 @@
+**Changed:**
+
+* Split `::intervalxt::sample::Arithmetic` into
+  `::intervalxt::sample::FloorDivision` and
+  `::intervalxt::sample::Coefficients`. The latter now accepts a vector of
+  elements and produces a vector of Q-vectors that correspond to the given
+  elements after being brought into the same vector space. This is a breaking
+  API change.
+
+* The method `Lengths::coefficients()` now expects a vector of labels and
+  produces a vector of Q-vectors corresponding to realizations of the
+  corresponding lengths in a common Q vector space.
+
+* The method `IntervalExchangeTransformation::safInvariant()` now returns a
+  `vector<mpq_class>` instead of a `valarray<mpq_class>`. The valarray had
+  always been a source of issues since it does not play nicely with vectors
+  that we use everywhere else in the flatsurf stack.

--- a/news/equivalent.rst
+++ b/news/equivalent.rst
@@ -1,0 +1,4 @@
+**Added:**
+
+* IntervalExchangeTransformation::equivalent() method to decide whether two
+  interval exchange transformations are equivalent modulo the precise labeling.

--- a/news/iet-py.rst
+++ b/news/iet-py.rst
@@ -1,0 +1,16 @@
+**Added:**
+
+* The `Lengths` of an `IntervalExchangeTransformation` are not available as
+  `iet.lengths` in Python. This is probably limited to interval exchange
+  transformations originally created through the Python interface.
+
+**Changed:**
+
+* In the Python interface, `IET` has been renamed to
+  `IntervalExchangeTransformation` and `makeLengths` to `Lengths`.
+
+* `sample::Lengths` over integer types now require `gmpxxll` to be available.
+
+**Fixed:**
+
+* Most labels now print nicely in the Python interface.

--- a/news/negative.rst
+++ b/news/negative.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* negative lengths are now detected in the Python interface and reported as an error, #85

--- a/pyintervalxt/src/pyintervalxt/__init__.py
+++ b/pyintervalxt/src/pyintervalxt/__init__.py
@@ -55,6 +55,33 @@ Check that #85 has been resolved:
     ...
     TypeError: ...all lengths must be non-negative...
 
+Check that #33 has been resolved::
+
+    >>> IntervalExchangeTransformation((1, 1, 1), (1, 0, 2)) == IntervalExchangeTransformation((1, 1, 1), (2, 1, 0))
+    False
+    >>> IntervalExchangeTransformation((3, 2, 1), (1, 0, 2)) == IntervalExchangeTransformation((1, 2, 3), (1, 0, 2))
+    False
+    >>> IntervalExchangeTransformation((3, 2, 1), (2, 1, 0)) == IntervalExchangeTransformation((3, 2, 1), (1, 2, 0))
+    False
+    >>> IntervalExchangeTransformation((1, 2, 3), (0, 1, 2)) == IntervalExchangeTransformation((1, 2, 3), (0, 1, 2))
+    True
+
+Note that such equality comparisons takes the names of the labels into account
+(actually, they use `Label::operator==` which is more complicated but behaves
+very predictably from the Python interface.) To ignore label naming completely,
+use `equivalent`::
+
+    >>> iet = IntervalExchangeTransformation((1, 1), (0, 1))
+    >>> jet = iet.reduce().value()
+    >>> iet
+    [a: 1] / [a]
+    >>> jet
+    [b: 1] / [b]
+    >>> iet == jet
+    False
+    >>> iet.equivalent(jet)
+    True
+
 """
 
 ######################################################################

--- a/pyintervalxt/src/pyintervalxt/__init__.py
+++ b/pyintervalxt/src/pyintervalxt/__init__.py
@@ -45,6 +45,16 @@ You can also use number algebraic lengths with pyeantic::
     >>> IntervalExchangeTransformation(lengths, [1, 0])
     [a: (a ~ 1.8392868)] [b: (2*a^2 - 3 ~ 3.7659515)] / [b] [a]
 
+TESTS:
+
+Check that #85 has been resolved:
+
+    >>> lengths = [L.gen(), eantic.renf_elem(L, "-3*a^2 + 2*a - 1")]
+    >>> IntervalExchangeTransformation(lengths, [1, 0])
+    Traceback (most recent call last):
+    ...
+    TypeError: ...all lengths must be non-negative...
+
 """
 
 ######################################################################

--- a/pyintervalxt/src/pyintervalxt/__init__.py
+++ b/pyintervalxt/src/pyintervalxt/__init__.py
@@ -4,18 +4,46 @@ A Python Interface to libintervalxt
 
 EXAMPLES::
 
-    >>> from pyintervalxt import IET
-    >>> iet = IET((18, 3), (1, 0))
+    >>> from pyintervalxt import IntervalExchangeTransformation
+    >>> iet = IntervalExchangeTransformation((18, 3), (1, 0))
     >>> iet
     [a: 18] [b: 3] / [b] [a]
-    
-TESTS:
+
+    >>> top = iet.top()
+    >>> top
+    [a, b]
+
+    >>> iet.lengths.labels()
+    [a, b]
+    >>> iet.lengths.get(top[0])
+    18
 
 Pickling works::
 
     >>> from pickle import loads, dumps
     >>> loads(dumps(iet))
     [a: 18] [b: 3] / [b] [a]
+
+The lengths in the above example are limited to small (32bit) integers, if you
+need larger entries, you might want to use mpz integers::
+
+    >>> from gmpxxyy import mpz
+    >>> IntervalExchangeTransformation((mpz(str(2**128)), mpz(1)), (1, 0))
+    [a: 340282366920938463463374607431768211456] [b: 1] / [b] [a]
+
+Rational numbers can be modeled with mpq fractions::
+
+    >>> from gmpxxyy import mpq
+    >>> IntervalExchangeTransformation((mpq(13, 37), mpq(23, 32)), (1, 0))
+    [a: 13/37] [b: 23/32] / [b] [a]
+
+You can also use number algebraic lengths with pyeantic::
+
+    >>> from pyeantic import eantic
+    >>> L = eantic.renf("a^3 - a^2 - a - 1", "a", "[1.84 +/- 0.01]")
+    >>> lengths = [L.gen(), eantic.renf_elem(L, "2*a^2 - 3")]
+    >>> IntervalExchangeTransformation(lengths, [1, 0])
+    [a: (a ~ 1.8392868)] [b: (2*a^2 - 3 ~ 3.7659515)] / [b] [a]
 
 """
 
@@ -39,4 +67,4 @@ Pickling works::
 #  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
 #####################################################################
 
-from .cppyy_intervalxt import intervalxt, IET
+from .cppyy_intervalxt import intervalxt, IntervalExchangeTransformation, Lengths

--- a/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
+++ b/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
@@ -18,9 +18,11 @@
 #  along with intervalxt. If not, see <https://www.gnu.org/licenses/>.
 #####################################################################
 
+import re
 import cppyy
 
 from cppyythonizations.pickling.cereal import enable_cereal
+from cppyythonizations.util import filtered
 
 # Importing cysignals after cppyy gives us proper stack traces on segfaults
 # whereas cppyy otherwise only reports "segmentation violation" (which is
@@ -32,60 +34,97 @@ if os.environ.get('PYINTERVALXT_CYSIGNALS', True):
     except ModuleNotFoundError:
         pass
 
-def make_iterable(proxy, name):
-    if hasattr(proxy, 'begin') and hasattr(proxy, 'end'):
-        if not hasattr(proxy, '__iter__'):
-            def iter(self):
-                i = self.begin()
-                while i != self.end():
-                    yield i.__deref__()
-                    i.__preinc__()
-
-            proxy.__iter__ = iter
-
-cppyy.py.add_pythonization(make_iterable, "intervalxt")
-
 def pretty_print(proxy, name):
     proxy.__repr__ = proxy.__str__
 
 cppyy.py.add_pythonization(pretty_print, "intervalxt")
 
 # Singleton object that makes sure that all Lengths that we have seen during
-# this cppyy session are known to cereal. This might break when lengths had
-# been loaded that are not available at unpickle time (even though they are
-# not needed) but there is nothing we can do about this unfortunately.
+# this cppyy session are known to cereal. This might break when unrelated
+# lengths types had been loaded at pickle time that are not available at
+# unpickle time (even though they are not needed) but there is nothing we can
+# do about this unfortunately.
 class LengthRegistrar:
     REGISTERED_LENGTHS = set()
 
     def __init__(self):
         self.known_lengths = set()
 
-    def track(self, name):
-        self.known_lengths.add(name)
+    def track(self, name, headers):
+        self.known_lengths.add((name, tuple(headers)))
 
     def __call__(self):
-        for length in self.known_lengths:
+        for length, headers in self.known_lengths:
             if length not in LengthRegistrar.REGISTERED_LENGTHS:
+                for header in headers:
+                    cppyy.include(header)
+
                 cppyy.cppdef('LIBINTERVALXT_ERASED_REGISTER((::intervalxt::Lengths), (%s));'%(length,))
             LengthRegistrar.REGISTERED_LENGTHS.add(length)
 
 lengthsRegistrar = LengthRegistrar()
 
 def enable_cereal_(proxy, name):
-    # Additional registration code is necessary for erased types such as
-    # Lengths. There seems to be no sane way to check this at runtime with
-    # cppyy. std::is_assignable_v lets too many types through that are
-    # actually not Lengths and performing an actual assignment lets cppyy
-    # crash in many cases.
-    if proxy.__cpp_name__.startswith('intervalxt::sample::Lengths<'):
-        lengthsRegistrar.track(proxy.__cpp_name__)
-
     headers = ["intervalxt/cereal.hpp", "intervalxt/sample/cereal.hpp", lengthsRegistrar]
 
     enable_cereal(proxy, name, headers)
 
 cppyy.py.add_pythonization(enable_cereal_, "intervalxt")
 cppyy.py.add_pythonization(enable_cereal_, "intervalxt::sample")
+cppyy.py.add_pythonization(enable_cereal_, "intervalxt::cppyy")
+
+def enable_label_printing(proxy, name):
+    r"""
+    Make labels print as "a", "b", "c" and not only as their memory address.
+
+    Labels do not have an intrinsic name. They only get a name in libintervalxt
+    once they are associated with a Lengths object.
+
+    To make them print nicely, we try to make sure that any code path tha
+    creates a label attaches the correct Lengths object to it and use it here
+    to print them nicely.
+    """
+    printer = None
+    def pretty_print(self):
+        if hasattr(self, "lengths"):
+            return self.lengths.render(self)
+        return printer(self)
+    printer = proxy.__repr__
+    proxy.__repr__ = pretty_print
+    proxy.__str__ = pretty_print
+
+def register_lengths(labels, lengths):
+    r"""
+    Helper function for enable_label_printing to actually register Lengths with
+    each label.
+    """
+    labels = list(labels)
+    for l in labels:
+        l.lengths = lengths
+    return labels
+
+def enable_register_lengths_iet(proxy, name):
+    r"""
+    Make sure that Label knows which Lengths it belongs to so it can print
+    nicely in Python.
+    """
+    top = proxy.top
+    proxy.top = lambda self: register_lengths(top(self), self.lengths)
+
+    bottom = proxy.bottom
+    proxy.bottom = lambda self: register_lengths(bottom(self), self.lengths)
+
+def enable_register_lengths(proxy, name):
+    r"""
+    Make sure that Label knows which Lengths it belongs to so it can print
+    nicely in Python.
+    """
+    labels = proxy.labels
+    proxy.labels = lambda self: register_lengths(labels(self), self)
+
+cppyy.py.add_pythonization(filtered("Label")(enable_label_printing), "intervalxt")
+cppyy.py.add_pythonization(filtered("IntervalExchangeTransformation")(enable_register_lengths_iet), "intervalxt")
+cppyy.py.add_pythonization(filtered(re.compile("Lengths<.*>"))(enable_register_lengths), "intervalxt::cppyy")
 
 # Set EXTRA_CLING_ARGS="-I /usr/include" or wherever intervalxt/cppyy.hpp can
 # be resolved if the following line fails to find the header file.
@@ -93,9 +132,50 @@ cppyy.include("intervalxt/cppyy.hpp")
 
 from cppyy.gbl import intervalxt
 
-def IET(lengths, permutation):
-    from cppyy.gbl import std
-    lengths = intervalxt.sample.Lengths[int](lengths)
-    return intervalxt.makeIET(lengths, permutation)
+def Lengths(lengths, headers=None):
+    if len(lengths) == 0:
+        raise ValueError("lengths must be non-empty")
 
-intervalxt.IET = IET
+    lengths = cppyy.gbl.std.vector(lengths)
+
+    # We cannot ask for lengths.value_type, due to
+    # https://bitbucket.org/wlav/cppyy/issues/269/typedef-lookup-fails-for-array-type
+    if headers is None:
+        if type(lengths) == cppyy.gbl.std.vector["int"]:
+            headers = ["intervalxt/sample/integer_coefficients.hpp", "intervalxt/sample/integer_floor_division.hpp"]
+        elif type(lengths) == cppyy.gbl.std.vector["mpz_class"]:
+            headers = ["intervalxt/sample/mpz_coefficients.hpp", "intervalxt/sample/mpz_floor_division.hpp"]
+        elif type(lengths) == cppyy.gbl.std.vector["mpq_class"]:
+            headers = ["intervalxt/sample/mpq_coefficients.hpp", "intervalxt/sample/mpq_floor_division.hpp"]
+        elif type(lengths) == cppyy.gbl.std.vector["eantic::renf_elem_class"]:
+            headers = ["intervalxt/sample/renf_elem_coefficients.hpp", "intervalxt/sample/renf_elem_floor_division.hpp"]
+        elif type(lengths) in [cppyy.gbl.std.vector["exactreal::Element<exactreal::IntegerRing>"], cppyy.gbl.std.vector["exactreal::Element<exactreal::IntegerRing>"], cppyy.gbl.std.vector["exactreal::Element<exactreal::IntegerRing>"]]:
+            headers = ["intervalxt/sample/element_coefficients.hpp", "intervalxt/sample/element_floor_division.hpp"]
+        else:
+            raise TypeError("unknown length type %s; you need to specify the headers that are needed to unpickle such lengths, i.e., the headers containing floor division and coefficients for that type"%(lengths))
+
+    for header in headers:
+        cppyy.include(header)
+
+    lengths = cppyy.gbl.intervalxt.cppyy.Lengths[type(lengths).__cpp_name__](lengths)
+
+    lengthsRegistrar.track(type(lengths).__cpp_name__, headers)
+
+    return lengths
+
+
+def IntervalExchangeTransformation(lengths, permutation):
+    if isinstance(lengths, (tuple, list)):
+        lengths = Lengths(lengths)
+
+    permutation = cppyy.gbl.std.vector[int](permutation)
+
+    iet = intervalxt.cppyy.IntervalExchangeTransformation(lengths, permutation)
+
+    iet.lengths = lengths
+
+    return iet
+
+# Hide the original sample::Lengths as instantiating them leads to segfaults in
+# cppyy, see https://bitbucket.org/wlav/cppyy/issues/268/segfault-with-types-in-unnamed-namespaces
+intervalxt.sample.Lengths = Lengths

--- a/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
+++ b/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
@@ -86,7 +86,7 @@ def enable_label_printing(proxy, name):
     """
     printer = None
     def pretty_print(self):
-        if hasattr(self, "lengths"):
+        if hasattr(self, "lengths") and self.lengths is not None:
             return self.lengths.render(self)
         return printer(self)
     printer = proxy.__repr__
@@ -109,10 +109,10 @@ def enable_register_lengths_iet(proxy, name):
     nicely in Python.
     """
     top = proxy.top
-    proxy.top = lambda self: register_lengths(top(self), self.lengths)
+    proxy.top = lambda self: register_lengths(top(self), self.lengths if hasattr(self, "lengths") else None)
 
     bottom = proxy.bottom
-    proxy.bottom = lambda self: register_lengths(bottom(self), self.lengths)
+    proxy.bottom = lambda self: register_lengths(bottom(self), self.lengths if hasattr(self, "lengths") else None)
 
 def enable_register_lengths(proxy, name):
     r"""

--- a/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
+++ b/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
@@ -34,10 +34,13 @@ if os.environ.get('PYINTERVALXT_CYSIGNALS', True):
     except ModuleNotFoundError:
         pass
 
+
 def pretty_print(proxy, name):
     proxy.__repr__ = proxy.__str__
 
+
 cppyy.py.add_pythonization(pretty_print, "intervalxt")
+
 
 # Singleton object that makes sure that all Lengths that we have seen during
 # this cppyy session are known to cereal. This might break when unrelated
@@ -62,6 +65,7 @@ class LengthRegistrar:
                 cppyy.cppdef('LIBINTERVALXT_ERASED_REGISTER((::intervalxt::Lengths), (%s));'%(length,))
             LengthRegistrar.REGISTERED_LENGTHS.add(length)
 
+
 lengthsRegistrar = LengthRegistrar()
 
 def enable_cereal_(proxy, name):
@@ -69,9 +73,11 @@ def enable_cereal_(proxy, name):
 
     enable_cereal(proxy, name, headers)
 
+
 cppyy.py.add_pythonization(enable_cereal_, "intervalxt")
 cppyy.py.add_pythonization(enable_cereal_, "intervalxt::sample")
 cppyy.py.add_pythonization(enable_cereal_, "intervalxt::cppyy")
+
 
 def enable_label_printing(proxy, name):
     r"""
@@ -93,6 +99,7 @@ def enable_label_printing(proxy, name):
     proxy.__repr__ = pretty_print
     proxy.__str__ = pretty_print
 
+
 def register_lengths(labels, lengths):
     r"""
     Helper function for enable_label_printing to actually register Lengths with
@@ -102,6 +109,7 @@ def register_lengths(labels, lengths):
     for l in labels:
         l.lengths = lengths
     return labels
+
 
 def enable_register_lengths_iet(proxy, name):
     r"""
@@ -114,6 +122,7 @@ def enable_register_lengths_iet(proxy, name):
     bottom = proxy.bottom
     proxy.bottom = lambda self: register_lengths(bottom(self), self.lengths if hasattr(self, "lengths") else None)
 
+
 def enable_register_lengths(proxy, name):
     r"""
     Make sure that Label knows which Lengths it belongs to so it can print
@@ -122,15 +131,19 @@ def enable_register_lengths(proxy, name):
     labels = proxy.labels
     proxy.labels = lambda self: register_lengths(labels(self), self)
 
+
 cppyy.py.add_pythonization(filtered("Label")(enable_label_printing), "intervalxt")
 cppyy.py.add_pythonization(filtered("IntervalExchangeTransformation")(enable_register_lengths_iet), "intervalxt")
 cppyy.py.add_pythonization(filtered(re.compile("Lengths<.*>"))(enable_register_lengths), "intervalxt::cppyy")
+
 
 # Set EXTRA_CLING_ARGS="-I /usr/include" or wherever intervalxt/cppyy.hpp can
 # be resolved if the following line fails to find the header file.
 cppyy.include("intervalxt/cppyy.hpp")
 
+
 from cppyy.gbl import intervalxt
+
 
 def Lengths(lengths, headers=None):
     if len(lengths) == 0:
@@ -175,6 +188,7 @@ def IntervalExchangeTransformation(lengths, permutation):
     iet.lengths = lengths
 
     return iet
+
 
 # Hide the original sample::Lengths as instantiating them leads to segfaults in
 # cppyy, see https://bitbucket.org/wlav/cppyy/issues/268/segfault-with-types-in-unnamed-namespaces

--- a/pyintervalxt/test/interval_exchange_transformation.py
+++ b/pyintervalxt/test/interval_exchange_transformation.py
@@ -24,27 +24,27 @@
 import sys
 import pytest
 
-from pyintervalxt import intervalxt
+from pyintervalxt import intervalxt, IntervalExchangeTransformation
 
 def test_IntervalExchangeTransformation():
-    iet = intervalxt.IET((18, 3), (1, 0))
+    iet = IntervalExchangeTransformation((18, 3), (1, 0))
     assert repr(iet) == "[a: 18] [b: 3] / [b] [a]"
     iet.swap()
     assert repr(iet) == "[b: 3] [a: 18] / [a] [b]"
 
 def test_reduce():
-    iet = intervalxt.IET((18, 3), (1, 0))
+    iet = IntervalExchangeTransformation((18, 3), (1, 0))
     r = iet.reduce()
     assert not r.has_value()
 
-    iet = intervalxt.IET((18, 3), (0, 1))
+    iet = IntervalExchangeTransformation((18, 3), (0, 1))
     r = iet.reduce()
     assert r.has_value()
     iet2 = r.value()
     assert repr(iet) == "[a: 18] / [a]"
     assert repr(iet2) == "[b: 3] / [b]"
 
-    iet = intervalxt.IET((4, 56, 23, 11, 21, 9, 65),(1, 0, 4, 3, 2, 6, 5))
+    iet = IntervalExchangeTransformation((4, 56, 23, 11, 21, 9, 65),(1, 0, 4, 3, 2, 6, 5))
     r = iet.reduce()
     assert r.has_value()
     iet2 = r.value()
@@ -72,14 +72,12 @@ def iet_10_check(iet):
 
 def test_mpz():
     from gmpxxyy import mpz
-    lengths = intervalxt.sample.Lengths[mpz]([1, 1])
-    iet = intervalxt.makeIET(lengths, [1, 0])
+    iet = IntervalExchangeTransformation((mpz(1), mpz(1)), [1, 0])
     iet_10_check(iet)
 
 def test_mpq():
     from gmpxxyy import mpq
-    lengths = intervalxt.sample.Lengths[mpq]([(1,3), (2,5)])
-    iet = intervalxt.makeIET(lengths, [1, 0])
+    iet = IntervalExchangeTransformation((mpq(1, 3), mpq(2, 5)), [1, 0])
     iet_10_check(iet)
 
 def test_eantic():
@@ -88,8 +86,7 @@ def test_eantic():
     lengths = []
     lengths.append(eantic.renf_elem(L, "a"))
     lengths.append(eantic.renf_elem(L, "2*a^2 - 3"))
-    lengths = intervalxt.sample.Lengths[eantic.renf_elem_class](lengths)
-    iet = intervalxt.makeIET(lengths, [1, 0])
+    iet = IntervalExchangeTransformation(lengths, [1, 0])
     iet_10_check(iet)
 
 if __name__ == '__main__': sys.exit(pytest.main(sys.argv))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,6 +69,8 @@ requirements:
     # enable test/pyintervalxt tests in ./configure
     - pytest
     - cppyy
+    # sample::Lengths needs gmpxxll.hpp
+    - gmpxxll
     # enable check-valgrind in ./configure
     - valgrind >=3.15.0
 {%- endif %}


### PR DESCRIPTION
otherwise, the rational coefficients might be unrelated, e.g., when one
element is rational and another one non-rational, the rational vector of
the former might have length 1 while the other does not. So it is
unclear for the calling code how they relate without knowing too much
implementation details.

Also, this splits the Arithmetic into floor division and coefficients.

Also fixes #94.

Note that this is a breaking API change since the interface of Lengths
has changed. Also, the names of the sample includes have changed.