### PR TITLE
Do not short-circuit decomposition algorithm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,7 @@ jobs:
       - name: check that gitignore is complete
         run: |
           [[ -n `git status --porcelain | grep '??'` ]]
-      - name: show logs
-        run: grep "" /dev/null `find -name '*.log'` || true
+      - uses: flatsurf/actions/show-logs@main
         if: ${{ always() }}
   test-pyintervalxt:
     runs-on: ubuntu-20.04
@@ -79,8 +78,7 @@ jobs:
           make
           cd pyintervalxt
           make ${{ matrix.target }}
-      - name: show logs
-        run: grep "" /dev/null `find -name '*.log'` || true
+      - uses: flatsurf/actions/show-logs@main
         if: ${{ always() }}
   distcheck:
     runs-on: ubuntu-20.04
@@ -101,8 +99,7 @@ jobs:
           ./bootstrap
           ./configure --prefix="$PREFIX"
           make distcheck
-      - name: show logs
-        run: grep "" /dev/null `find -name '*.log'` || true
+      - uses: flatsurf/actions/show-logs@main
         if: ${{ always() }}
 
 env:

--- a/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
+++ b/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
@@ -105,8 +105,8 @@ def name_label(labels, name):
 cppyy.py.add_pythonization(filtered("Label")(wrap_method("__str__")(lambda self, __str__: self._name if hasattr(self, "_name") else __str__())), "intervalxt")
 
 
-cppyy.py.add_pythonization(filtered("IntervalExchangeTransformation")(wrap_method("top")(lambda self, top: name_label(top(), self.lengths.render if hasattr(self, "lengths") else str))), "intervalxt")
-cppyy.py.add_pythonization(filtered("IntervalExchangeTransformation")(wrap_method("bottom")(lambda self, bottom: name_label(bottom(), self.lengths.render if hasattr(self, "lengths") else str))), "intervalxt")
+cppyy.py.add_pythonization(filtered("IntervalExchangeTransformation")(wrap_method("top")(lambda self, top: name_label(top(), self.lengths().render if hasattr(self, "lengths") else str))), "intervalxt")
+cppyy.py.add_pythonization(filtered("IntervalExchangeTransformation")(wrap_method("bottom")(lambda self, bottom: name_label(bottom(), self.lengths().render if hasattr(self, "lengths") else str))), "intervalxt")
 cppyy.py.add_pythonization(filtered(re.compile("Lengths<.*>"))(wrap_method("labels")(lambda self, labels: name_label(labels(), self.render))), "intervalxt::cppyy")
 cppyy.py.add_pythonization(filtered(re.compile("Lengths<.*>"))(wrap_method("render")(lambda self, render, label: str(render(label)))), "intervalxt::cppyy")
 
@@ -159,7 +159,7 @@ def IntervalExchangeTransformation(lengths, permutation):
 
     iet = intervalxt.cppyy.IntervalExchangeTransformation(lengths, permutation)
 
-    iet.lengths = lengths
+    iet.lengths = lambda: lengths
 
     return iet
 

--- a/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
+++ b/pyintervalxt/src/pyintervalxt/cppyy_intervalxt.py
@@ -160,6 +160,11 @@ def IntervalExchangeTransformation(lengths, permutation):
     iet = intervalxt.cppyy.IntervalExchangeTransformation(lengths, permutation)
 
     iet.lengths = lambda: lengths
+    # In a previous iteration of pyintervalxt, iet.lengths was a property and
+    # not a method (as it is in the C++ interface.) To keep backwards
+    # compatibility, we expose all of lengths() on lengths itself.
+    for attr in dir(lengths):
+        if not attr.startswith('__'): setattr(iet.lengths, attr, getattr(lengths, attr))
 
     return iet
 


### PR DESCRIPTION
fixes #156

What happened before: An IET A splits as B|A'. B remains undetermined
and exceeds the limit in the recursion. Now, A' splits again as C|A". C
has only a single interval but because of the short-circuiting it is
never looked at.